### PR TITLE
Combined tests + fix race

### DIFF
--- a/cln_client.go
+++ b/cln_client.go
@@ -43,25 +43,23 @@ func (c *ClnClient) GetInfo() (*GetInfoResult, error) {
 	}, nil
 }
 
-func (c *ClnClient) IsConnected(destination []byte) (*bool, error) {
+func (c *ClnClient) IsConnected(destination []byte) (bool, error) {
 	pubKey := hex.EncodeToString(destination)
 	peers, err := c.client.ListPeers()
 	if err != nil {
 		log.Printf("CLN: client.ListPeers() error: %v", err)
-		return nil, fmt.Errorf("CLN: client.ListPeers() error: %w", err)
+		return false, fmt.Errorf("CLN: client.ListPeers() error: %w", err)
 	}
 
 	for _, peer := range peers {
 		if pubKey == peer.Id {
 			log.Printf("destination online: %x", destination)
-			result := true
-			return &result, nil
+			return true, nil
 		}
 	}
 
 	log.Printf("CLN: destination offline: %x", destination)
-	result := false
-	return &result, nil
+	return false, nil
 }
 
 func (c *ClnClient) OpenChannel(req *OpenChannelRequest) (*wire.OutPoint, error) {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/aws/aws-sdk-go v1.30.20
-	github.com/breez/lntest v0.0.3
+	github.com/breez/lntest v0.0.6
 	github.com/btcsuite/btcd v0.23.1
 	github.com/btcsuite/btcd/btcec/v2 v2.2.1
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1
@@ -176,4 +176,4 @@ require (
 
 replace github.com/lightningnetwork/lnd v0.15.1-beta => github.com/breez/lnd v0.15.0-beta.rc6.0.20220831104847-00b86a81e57a
 
-replace github.com/niftynei/glightning v0.8.2 => github.com/breez/glightning v0.0.0-20221124075140-383be4672b47
+replace github.com/niftynei/glightning v0.8.2 => github.com/breez/glightning v0.0.0-20221201092709-02feadd1d0ad

--- a/itest/lspd_test.go
+++ b/itest/lspd_test.go
@@ -1,0 +1,70 @@
+package itest
+
+import (
+	"fmt"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/breez/lntest"
+)
+
+var defaultTimeout time.Duration = time.Second * 120
+
+func TestLspd(t *testing.T) {
+	testCases := allTestCases
+	// runTests(t, testCases, "LND-lspd", func(h *lntest.TestHarness, m *lntest.Miner, t time.Time) LspNode {
+	// 	return NewLndLspdNode(h, m, "lsp", t)
+	// })
+
+	runTests(t, testCases, "CLN-lspd", func(h *lntest.TestHarness, m *lntest.Miner, t time.Time) LspNode {
+		return NewClnLspdNode(h, m, "lsp", t)
+	})
+}
+
+func runTests(t *testing.T, testCases []*testCase, prefix string, lspFunc func(h *lntest.TestHarness, m *lntest.Miner, t time.Time) LspNode) {
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(fmt.Sprintf("%s: %s", prefix, testCase.name), func(t *testing.T) {
+			runTest(t, testCase, prefix, lspFunc)
+		})
+	}
+}
+
+func runTest(t *testing.T, testCase *testCase, prefix string, lspFunc func(h *lntest.TestHarness, m *lntest.Miner, t time.Time) LspNode) {
+	log.Printf("%s: Running test case '%s'", prefix, testCase.name)
+	harness := lntest.NewTestHarness(t)
+	defer harness.TearDown()
+
+	var dd time.Duration
+	to := testCase.timeout
+	if to == dd {
+		to = defaultTimeout
+	}
+
+	timeout := time.Now().Add(to)
+	log.Printf("Using timeout %v", timeout.String())
+	log.Printf("Creating miner")
+	miner := lntest.NewMiner(harness)
+	log.Printf("Creating lsp")
+	lsp := lspFunc(harness, miner, timeout)
+	log.Printf("Run testcase")
+	testCase.test(harness, lsp, miner, timeout)
+}
+
+type testCase struct {
+	name    string
+	test    func(h *lntest.TestHarness, lsp LspNode, miner *lntest.Miner, timeout time.Time)
+	timeout time.Duration
+}
+
+var allTestCases = []*testCase{
+	{
+		name: "testOpenZeroConfChannelOnReceive",
+		test: testOpenZeroConfChannelOnReceive,
+	},
+	{
+		name: "testOpenZeroConfSingleHtlc",
+		test: testOpenZeroConfSingleHtlc,
+	},
+}

--- a/lightning_client.go
+++ b/lightning_client.go
@@ -23,7 +23,7 @@ type OpenChannelRequest struct {
 
 type LightningClient interface {
 	GetInfo() (*GetInfoResult, error)
-	IsConnected(destination []byte) (*bool, error)
+	IsConnected(destination []byte) (bool, error)
 	OpenChannel(req *OpenChannelRequest) (*wire.OutPoint, error)
 	GetChannel(peerID []byte, channelPoint wire.OutPoint) (*GetChannelResult, error)
 	GetNodeChannelCount(nodeID []byte) (int, error)

--- a/lnd_macaroon_credential.go
+++ b/lnd_macaroon_credential.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"context"
+)
+
+type MacaroonCredential struct {
+	MacaroonHex string
+}
+
+func NewMacaroonCredential(hex string) *MacaroonCredential {
+	return &MacaroonCredential{
+		MacaroonHex: hex,
+	}
+}
+
+func (m *MacaroonCredential) RequireTransportSecurity() bool {
+	return true
+}
+
+func (m *MacaroonCredential) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
+	md := make(map[string]string)
+	md["macaroon"] = m.MacaroonHex
+	return md, nil
+}


### PR DESCRIPTION
- Combine the tests for CLN and LND. Any integration test written will run on both LND lsp and CLN lsp. (LND tests are commented out now, because they fail to open a channel with Bob, because Bob (CLN) does not support `option_anchors_zero_fee_htlc_tx`, and LND requires that when opening an anchor channel.)
- Reuse open channel logic between CLN and LND. There was a race condition between opening the channel and inserting the channel in the database (the latter happened outside the payment hash lock). This fixes that race condition.
- Put the macaroon on every request automatically, using PerRPCCredentials
