### PR TITLE
Support CLN v22.11

### DIFF
--- a/cln_client.go
+++ b/cln_client.go
@@ -43,25 +43,23 @@ func (c *ClnClient) GetInfo() (*GetInfoResult, error) {
 	}, nil
 }
 
-func (c *ClnClient) IsConnected(destination []byte) (*bool, error) {
+func (c *ClnClient) IsConnected(destination []byte) (bool, error) {
 	pubKey := hex.EncodeToString(destination)
 	peers, err := c.client.ListPeers()
 	if err != nil {
 		log.Printf("CLN: client.ListPeers() error: %v", err)
-		return nil, fmt.Errorf("CLN: client.ListPeers() error: %w", err)
+		return false, fmt.Errorf("CLN: client.ListPeers() error: %w", err)
 	}
 
 	for _, peer := range peers {
 		if pubKey == peer.Id {
 			log.Printf("destination online: %x", destination)
-			result := true
-			return &result, nil
+			return true, nil
 		}
 	}
 
 	log.Printf("CLN: destination offline: %x", destination)
-	result := false
-	return &result, nil
+	return false, nil
 }
 
 func (c *ClnClient) OpenChannel(req *OpenChannelRequest) (*wire.OutPoint, error) {

--- a/cln_interceptor.go
+++ b/cln_interceptor.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	sphinx "github.com/lightningnetwork/lightning-onion"
+	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/record"
 	"github.com/lightningnetwork/lnd/tlv"
 	"github.com/niftynei/glightning/glightning"
@@ -120,8 +121,9 @@ func (i *ClnHtlcInterceptor) resumeWithOnion(event *glightning.HtlcAcceptedEvent
 		return event.Fail(uint16(FAILURE_TEMPORARY_CHANNEL_FAILURE))
 	}
 
+	chanId := lnwire.NewChanIDFromOutPoint(interceptResult.channelPoint)
 	log.Printf("forwarding htlc to the destination node and a new private channel was opened")
-	return event.ContinueWithPayload(newPayload)
+	return event.ContinueWith(chanId.String(), newPayload)
 }
 
 func encodePayloadWithNextHop(payloadHex string, channelId uint64) (string, error) {

--- a/db.go
+++ b/db.go
@@ -62,7 +62,7 @@ func setFundingTx(paymentHash []byte, channelPoint *wire.OutPoint) error {
 			SET funding_tx_id = $2, funding_tx_outnum = $3
 			WHERE payment_hash=$1`,
 		paymentHash, channelPoint.Hash[:], channelPoint.Index)
-	log.Printf("setFundingTx(%x, %x, %v): %s err: %v", paymentHash, channelPoint.Hash[:], channelPoint.Index, commandTag, err)
+	log.Printf("setFundingTx(%x, %s, %d): %s err: %v", paymentHash, channelPoint.Hash.String(), channelPoint.Index, commandTag, err)
 	return err
 }
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/aws/aws-sdk-go v1.30.20
-	github.com/breez/lntest v0.0.6
+	github.com/breez/lntest v0.0.7
 	github.com/btcsuite/btcd v0.23.1
 	github.com/btcsuite/btcd/btcec/v2 v2.2.1
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1
@@ -176,4 +176,4 @@ require (
 
 replace github.com/lightningnetwork/lnd v0.15.1-beta => github.com/breez/lnd v0.15.0-beta.rc6.0.20220831104847-00b86a81e57a
 
-replace github.com/niftynei/glightning v0.8.2 => github.com/breez/glightning v0.0.0-20221201092709-02feadd1d0ad
+replace github.com/niftynei/glightning v0.8.2 => github.com/breez/glightning v0.0.0-20221207122347-03c2d8cb69dd

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/aws/aws-sdk-go v1.30.20
-	github.com/breez/lntest v0.0.3
+	github.com/breez/lntest v0.0.6
 	github.com/btcsuite/btcd v0.23.1
 	github.com/btcsuite/btcd/btcec/v2 v2.2.1
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1
@@ -176,4 +176,4 @@ require (
 
 replace github.com/lightningnetwork/lnd v0.15.1-beta => github.com/breez/lnd v0.15.0-beta.rc6.0.20220831104847-00b86a81e57a
 
-replace github.com/niftynei/glightning v0.8.2 => github.com/breez/glightning v0.0.0-20221124075140-383be4672b47
+replace github.com/niftynei/glightning v0.8.2 => github.com/breez/glightning v0.0.0-20221201092709-02feadd1d0ad

--- a/itest/intercept_zero_conf_test.go
+++ b/itest/intercept_zero_conf_test.go
@@ -2,25 +2,24 @@ package itest
 
 import (
 	"log"
-	"time"
 
 	"github.com/breez/lntest"
 	lspd "github.com/breez/lspd/rpc"
 	"gotest.tools/assert"
 )
 
-func testOpenZeroConfChannelOnReceive(h *lntest.TestHarness, lsp LspNode, miner *lntest.Miner, timeout time.Time) {
-	alice := lntest.NewCoreLightningNode(h, miner, "Alice", timeout)
-	bob := NewZeroConfNode(h, miner, "Bob", timeout)
+func testOpenZeroConfChannelOnReceive(h *lntest.TestHarness, lsp LspNode, miner *lntest.Miner) {
+	alice := lntest.NewCoreLightningNode(h, miner, "Alice")
+	bob := NewZeroConfNode(h, miner, "Bob")
 
-	alice.Fund(10000000, timeout)
-	lsp.LightningNode().Fund(10000000, timeout)
+	alice.Fund(10000000)
+	lsp.LightningNode().Fund(10000000)
 
 	log.Print("Opening channel between Alice and the lsp")
 	channel := alice.OpenChannel(lsp.LightningNode(), &lntest.OpenChannelOptions{
 		AmountSat: 1000000,
 	})
-	alice.WaitForChannelReady(channel, timeout)
+	alice.WaitForChannelReady(channel)
 
 	log.Printf("Adding bob's invoices")
 	outerAmountMsat := uint64(2100000)
@@ -48,25 +47,25 @@ func testOpenZeroConfChannelOnReceive(h *lntest.TestHarness, lsp LspNode, miner 
 	})
 
 	log.Printf("Alice paying")
-	payResp := alice.Pay(outerInvoice.bolt11, timeout)
+	payResp := alice.Pay(outerInvoice.bolt11)
 	bobInvoice := bob.lightningNode.GetInvoice(payResp.PaymentHash)
 
 	assert.DeepEqual(h.T, payResp.PaymentPreimage, bobInvoice.PaymentPreimage)
 	assert.Equal(h.T, outerAmountMsat, bobInvoice.AmountReceivedMsat)
 }
 
-func testOpenZeroConfSingleHtlc(h *lntest.TestHarness, lsp LspNode, miner *lntest.Miner, timeout time.Time) {
-	alice := lntest.NewCoreLightningNode(h, miner, "Alice", timeout)
-	bob := NewZeroConfNode(h, miner, "Bob", timeout)
+func testOpenZeroConfSingleHtlc(h *lntest.TestHarness, lsp LspNode, miner *lntest.Miner) {
+	alice := lntest.NewCoreLightningNode(h, miner, "Alice")
+	bob := NewZeroConfNode(h, miner, "Bob")
 
-	alice.Fund(10000000, timeout)
-	lsp.LightningNode().Fund(10000000, timeout)
+	alice.Fund(10000000)
+	lsp.LightningNode().Fund(10000000)
 
 	log.Print("Opening channel between Alice and the lsp")
 	channel := alice.OpenChannel(lsp.LightningNode(), &lntest.OpenChannelOptions{
 		AmountSat: 1000000,
 	})
-	channelId := alice.WaitForChannelReady(channel, timeout)
+	channelId := alice.WaitForChannelReady(channel)
 
 	log.Printf("Adding bob's invoices")
 	outerAmountMsat := uint64(2100000)
@@ -95,7 +94,7 @@ func testOpenZeroConfSingleHtlc(h *lntest.TestHarness, lsp LspNode, miner *lntes
 
 	log.Printf("Alice paying")
 	route := constructRoute(lsp.LightningNode(), bob.lightningNode, channelId, lntest.NewShortChanIDFromString("1x0x0"), outerAmountMsat)
-	payResp := alice.PayViaRoute(outerAmountMsat, outerInvoice.paymentHash, outerInvoice.paymentSecret, route, timeout)
+	payResp := alice.PayViaRoute(outerAmountMsat, outerInvoice.paymentHash, outerInvoice.paymentSecret, route)
 	bobInvoice := bob.lightningNode.GetInvoice(payResp.PaymentHash)
 
 	assert.DeepEqual(h.T, payResp.PaymentPreimage, bobInvoice.PaymentPreimage)

--- a/itest/lspd_node.go
+++ b/itest/lspd_node.go
@@ -2,7 +2,7 @@ package itest
 
 import (
 	"bufio"
-	context "context"
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -10,7 +10,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/breez/lntest"
 	"github.com/breez/lspd/btceclegacy"
@@ -18,7 +17,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/golang/protobuf/proto"
-	grpc "google.golang.org/grpc"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
 
@@ -135,7 +134,7 @@ func (l *LndLspNode) LightningNode() lntest.LightningNode {
 	return l.lightningNode
 }
 
-func NewClnLspdNode(h *lntest.TestHarness, m *lntest.Miner, name string, timeout time.Time) LspNode {
+func NewClnLspdNode(h *lntest.TestHarness, m *lntest.Miner, name string) LspNode {
 	scriptFilePath, grpcAddress, publ, postgresBackend := setupLspd(h, name, "RUN_CLN=true")
 	args := []string{
 		fmt.Sprintf("--plugin=%s", scriptFilePath),
@@ -144,7 +143,7 @@ func NewClnLspdNode(h *lntest.TestHarness, m *lntest.Miner, name string, timeout
 		fmt.Sprintf("--cltv-delta=%d", lspCltvDelta),
 	}
 
-	lightningNode := lntest.NewCoreLightningNode(h, m, name, timeout, args...)
+	lightningNode := lntest.NewCoreLightningNode(h, m, name, args...)
 
 	conn, err := grpc.Dial(
 		grpcAddress,
@@ -168,7 +167,7 @@ func NewClnLspdNode(h *lntest.TestHarness, m *lntest.Miner, name string, timeout
 	return lspNode
 }
 
-func NewLndLspdNode(h *lntest.TestHarness, m *lntest.Miner, name string, timeout time.Time) LspNode {
+func NewLndLspdNode(h *lntest.TestHarness, m *lntest.Miner, name string) LspNode {
 	args := []string{
 		"--protocol.zero-conf",
 		"--protocol.option-scid-alias",
@@ -180,7 +179,7 @@ func NewLndLspdNode(h *lntest.TestHarness, m *lntest.Miner, name string, timeout
 		fmt.Sprintf("--bitcoin.timelockdelta=%d", lspCltvDelta),
 	}
 
-	lightningNode := lntest.NewLndNode(h, m, name, timeout, args...)
+	lightningNode := lntest.NewLndNode(h, m, name, args...)
 	tlsCert := strings.Replace(string(lightningNode.TlsCert()), "\n", "\\n", -1)
 	scriptFilePath, grpcAddress, publ, postgresBackend := setupLspd(h, name,
 		"RUN_LND=true",

--- a/itest/lspd_test.go
+++ b/itest/lspd_test.go
@@ -13,16 +13,16 @@ var defaultTimeout time.Duration = time.Second * 120
 
 func TestLspd(t *testing.T) {
 	testCases := allTestCases
-	// runTests(t, testCases, "LND-lspd", func(h *lntest.TestHarness, m *lntest.Miner, t time.Time) LspNode {
-	// 	return NewLndLspdNode(h, m, "lsp", t)
+	// runTests(t, testCases, "LND-lspd", func(h *lntest.TestHarness, m *lntest.Miner) LspNode {
+	// 	return NewLndLspdNode(h, m, "lsp")
 	// })
 
-	runTests(t, testCases, "CLN-lspd", func(h *lntest.TestHarness, m *lntest.Miner, t time.Time) LspNode {
-		return NewClnLspdNode(h, m, "lsp", t)
+	runTests(t, testCases, "CLN-lspd", func(h *lntest.TestHarness, m *lntest.Miner) LspNode {
+		return NewClnLspdNode(h, m, "lsp")
 	})
 }
 
-func runTests(t *testing.T, testCases []*testCase, prefix string, lspFunc func(h *lntest.TestHarness, m *lntest.Miner, t time.Time) LspNode) {
+func runTests(t *testing.T, testCases []*testCase, prefix string, lspFunc func(h *lntest.TestHarness, m *lntest.Miner) LspNode) {
 	for _, testCase := range testCases {
 		testCase := testCase
 		t.Run(fmt.Sprintf("%s: %s", prefix, testCase.name), func(t *testing.T) {
@@ -31,30 +31,31 @@ func runTests(t *testing.T, testCases []*testCase, prefix string, lspFunc func(h
 	}
 }
 
-func runTest(t *testing.T, testCase *testCase, prefix string, lspFunc func(h *lntest.TestHarness, m *lntest.Miner, t time.Time) LspNode) {
+func runTest(t *testing.T, testCase *testCase, prefix string, lspFunc func(h *lntest.TestHarness, m *lntest.Miner) LspNode) {
 	log.Printf("%s: Running test case '%s'", prefix, testCase.name)
-	harness := lntest.NewTestHarness(t)
-	defer harness.TearDown()
-
 	var dd time.Duration
 	to := testCase.timeout
 	if to == dd {
 		to = defaultTimeout
 	}
 
-	timeout := time.Now().Add(to)
-	log.Printf("Using timeout %v", timeout.String())
+	deadline := time.Now().Add(to)
+	log.Printf("Using deadline %v", deadline.String())
+
+	harness := lntest.NewTestHarness(t, deadline)
+	defer harness.TearDown()
+
 	log.Printf("Creating miner")
 	miner := lntest.NewMiner(harness)
 	log.Printf("Creating lsp")
-	lsp := lspFunc(harness, miner, timeout)
+	lsp := lspFunc(harness, miner)
 	log.Printf("Run testcase")
-	testCase.test(harness, lsp, miner, timeout)
+	testCase.test(harness, lsp, miner)
 }
 
 type testCase struct {
 	name    string
-	test    func(h *lntest.TestHarness, lsp LspNode, miner *lntest.Miner, timeout time.Time)
+	test    func(h *lntest.TestHarness, lsp LspNode, miner *lntest.Miner)
 	timeout time.Duration
 }
 

--- a/itest/lspd_test.go
+++ b/itest/lspd_test.go
@@ -1,0 +1,70 @@
+package itest
+
+import (
+	"fmt"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/breez/lntest"
+)
+
+var defaultTimeout time.Duration = time.Second * 120
+
+func TestLspd(t *testing.T) {
+	testCases := allTestCases
+	// runTests(t, testCases, "LND-lspd", func(h *lntest.TestHarness, m *lntest.Miner, t time.Time) LspNode {
+	// 	return NewLndLspdNode(h, m, "lsp", t)
+	// })
+
+	runTests(t, testCases, "CLN-lspd", func(h *lntest.TestHarness, m *lntest.Miner, t time.Time) LspNode {
+		return NewClnLspdNode(h, m, "lsp", t)
+	})
+}
+
+func runTests(t *testing.T, testCases []*testCase, prefix string, lspFunc func(h *lntest.TestHarness, m *lntest.Miner, t time.Time) LspNode) {
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(fmt.Sprintf("%s: %s", prefix, testCase.name), func(t *testing.T) {
+			runTest(t, testCase, prefix, lspFunc)
+		})
+	}
+}
+
+func runTest(t *testing.T, testCase *testCase, prefix string, lspFunc func(h *lntest.TestHarness, m *lntest.Miner, t time.Time) LspNode) {
+	log.Printf("%s: Running test case '%s'", prefix, testCase.name)
+	harness := lntest.NewTestHarness(t)
+	defer harness.TearDown()
+
+	var dd time.Duration
+	to := testCase.timeout
+	if to == dd {
+		to = defaultTimeout
+	}
+
+	timeout := time.Now().Add(to)
+	log.Printf("Using timeout %v", timeout.String())
+	log.Printf("Creating miner")
+	miner := lntest.NewMiner(harness)
+	log.Printf("Creating lsp")
+	lsp := lspFunc(harness, miner, timeout)
+	log.Printf("Run testcase")
+	testCase.test(harness, lsp, miner, timeout)
+}
+
+type testCase struct {
+	name    string
+	test    func(h *lntest.TestHarness, lsp LspNode, miner *lntest.Miner, timeout time.Time)
+	timeout time.Duration
+}
+
+var allTestCases = []*testCase{
+	{
+		name: "testOpenZeroConfChannelOnReceive",
+		test: testOpenZeroConfChannelOnReceive,
+	},
+	{
+		name: "testOpenZeroConfSingleHtlc",
+		test: testOpenZeroConfSingleHtlc,
+	},
+}

--- a/itest/zero_conf_node.go
+++ b/itest/zero_conf_node.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/breez/lntest"
 	btcec "github.com/btcsuite/btcd/btcec/v2"
@@ -51,7 +50,7 @@ pip install pyln-client > /dev/null 2>&1
 python %s
 `
 
-func NewZeroConfNode(h *lntest.TestHarness, m *lntest.Miner, name string, timeout time.Time) *ZeroConfNode {
+func NewZeroConfNode(h *lntest.TestHarness, m *lntest.Miner, name string) *ZeroConfNode {
 	privKey, err := btcec.NewPrivateKey()
 	lntest.CheckError(h.T, err)
 
@@ -89,7 +88,6 @@ func NewZeroConfNode(h *lntest.TestHarness, m *lntest.Miner, name string, timeou
 		h,
 		m,
 		name,
-		timeout,
 		fmt.Sprintf("--dev-force-privkey=%x", s),
 		fmt.Sprintf("--plugin=%s", pluginFilePath),
 	)

--- a/lightning_client.go
+++ b/lightning_client.go
@@ -23,7 +23,7 @@ type OpenChannelRequest struct {
 
 type LightningClient interface {
 	GetInfo() (*GetInfoResult, error)
-	IsConnected(destination []byte) (*bool, error)
+	IsConnected(destination []byte) (bool, error)
 	OpenChannel(req *OpenChannelRequest) (*wire.OutPoint, error)
 	GetChannel(peerID []byte, channelPoint wire.OutPoint) (*GetChannelResult, error)
 	GetNodeChannelCount(nodeID []byte) (int, error)

--- a/lnd_macaroon_credential.go
+++ b/lnd_macaroon_credential.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"context"
+)
+
+type MacaroonCredential struct {
+	MacaroonHex string
+}
+
+func NewMacaroonCredential(hex string) *MacaroonCredential {
+	return &MacaroonCredential{
+		MacaroonHex: hex,
+	}
+}
+
+func (m *MacaroonCredential) RequireTransportSecurity() bool {
+	return true
+}
+
+func (m *MacaroonCredential) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
+	md := make(map[string]string)
+	md["macaroon"] = m.MacaroonHex
+	return md, nil
+}


### PR DESCRIPTION
We have to pass `forward_to` with the channelid of the newly created channel to the `htlc_accepted` hook. (new in CLN v22.11)

I hope the endianness of the channelid is correct on all devices. I'm reversing the byte order of the fundingtxid in order to convert it to a format LND's `wire.Outpoint` understands.

This PR depends on https://github.com/breez/lspd/pull/25. Only commit https://github.com/breez/lspd/pull/29/commits/175db55c010e026e0b2a08523eab7be8dbd522ce is added.