### PR TITLE
Add itest for offline Breez client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/aws/aws-sdk-go v1.30.20
-	github.com/breez/lntest v0.0.12
+	github.com/breez/lntest v0.0.13
 	github.com/btcsuite/btcd v0.23.3
 	github.com/btcsuite/btcd/btcec/v2 v2.2.1
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/aws/aws-sdk-go v1.30.20
-	github.com/breez/lntest v0.0.11
+	github.com/breez/lntest v0.0.12
 	github.com/btcsuite/btcd v0.23.3
 	github.com/btcsuite/btcd/btcec/v2 v2.2.1
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1
@@ -43,7 +43,6 @@ require (
 )
 
 require (
-	github.com/Yawning/aez v0.0.0-20211027044916-e49e68abd344 // indirect
 	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da // indirect
 	github.com/aead/siphash v1.0.1 // indirect
 	github.com/andybalholm/brotli v1.0.3 // indirect
@@ -137,7 +136,6 @@ require (
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect
-	gitlab.com/yawning/bsaes.git v0.0.0-20190805113838-0a714cd429ec // indirect
 	go.etcd.io/bbolt v1.3.6 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.0 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.0 // indirect
@@ -178,4 +176,4 @@ require (
 
 replace github.com/lightningnetwork/lnd v0.15.4-beta => github.com/breez/lnd v0.15.0-beta.rc6.0.20220831104847-00b86a81e57a
 
-replace github.com/niftynei/glightning v0.8.2 => github.com/breez/glightning v0.0.0-20221207132824-fb0b6f4f7483
+replace github.com/niftynei/glightning v0.8.2 => github.com/breez/glightning v0.0.0-20221216194006-8e9b65bdcbfc

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/aws/aws-sdk-go v1.30.20
-	github.com/breez/lntest v0.0.10
+	github.com/breez/lntest v0.0.11
 	github.com/btcsuite/btcd v0.23.3
 	github.com/btcsuite/btcd/btcec/v2 v2.2.1
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1

--- a/intercept.go
+++ b/intercept.go
@@ -22,14 +22,14 @@ type interceptAction int
 const (
 	INTERCEPT_RESUME              interceptAction = 0
 	INTERCEPT_RESUME_WITH_ONION   interceptAction = 1
-	INTERCEPT_FAIL_HTLC           interceptAction = 2
-	INTERCEPT_FAIL_HTLC_WITH_CODE interceptAction = 3
+	INTERCEPT_FAIL_HTLC_WITH_CODE interceptAction = 2
 )
 
 type interceptFailureCode uint16
 
 var (
 	FAILURE_TEMPORARY_CHANNEL_FAILURE            interceptFailureCode = 0x1007
+	FAILURE_TEMPORARY_NODE_FAILURE               interceptFailureCode = 0x2002
 	FAILURE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS interceptFailureCode = 0x4015
 )
 
@@ -52,7 +52,8 @@ func intercept(reqPaymentHash []byte, reqOutgoingAmountMsat uint64, reqOutgoingE
 		if err != nil {
 			log.Printf("paymentInfo(%x) error: %v", reqPaymentHash, err)
 			return interceptResult{
-				action: INTERCEPT_FAIL_HTLC,
+				action:      INTERCEPT_FAIL_HTLC_WITH_CODE,
+				failureCode: FAILURE_TEMPORARY_NODE_FAILURE,
 			}, nil
 		}
 		log.Printf("paymentHash:%x\npaymentSecret:%x\ndestination:%x\nincomingAmountMsat:%v\noutgoingAmountMsat:%v",
@@ -69,7 +70,8 @@ func intercept(reqPaymentHash []byte, reqOutgoingAmountMsat uint64, reqOutgoingE
 				if err != nil {
 					log.Printf("openChannel(%x, %v) err: %v", destination, incomingAmountMsat, err)
 					return interceptResult{
-						action: INTERCEPT_FAIL_HTLC,
+						action:      INTERCEPT_FAIL_HTLC_WITH_CODE,
+						failureCode: FAILURE_TEMPORARY_CHANNEL_FAILURE,
 					}, nil
 				}
 			} else { //probing
@@ -90,7 +92,8 @@ func intercept(reqPaymentHash []byte, reqOutgoingAmountMsat uint64, reqOutgoingE
 		if err != nil {
 			log.Printf("btcec.ParsePubKey(%x): %v", destination, err)
 			return interceptResult{
-				action: INTERCEPT_FAIL_HTLC,
+				action:      INTERCEPT_FAIL_HTLC_WITH_CODE,
+				failureCode: FAILURE_TEMPORARY_CHANNEL_FAILURE,
 			}, nil
 		}
 
@@ -98,7 +101,8 @@ func intercept(reqPaymentHash []byte, reqOutgoingAmountMsat uint64, reqOutgoingE
 		if err != nil {
 			log.Printf("btcec.NewPrivateKey(): %v", err)
 			return interceptResult{
-				action: INTERCEPT_FAIL_HTLC,
+				action:      INTERCEPT_FAIL_HTLC_WITH_CODE,
+				failureCode: FAILURE_TEMPORARY_CHANNEL_FAILURE,
 			}, nil
 		}
 
@@ -119,7 +123,8 @@ func intercept(reqPaymentHash []byte, reqOutgoingAmountMsat uint64, reqOutgoingE
 		if err != nil {
 			log.Printf("hop.PackHopPayload(): %v", err)
 			return interceptResult{
-				action: INTERCEPT_FAIL_HTLC,
+				action:      INTERCEPT_FAIL_HTLC_WITH_CODE,
+				failureCode: FAILURE_TEMPORARY_CHANNEL_FAILURE,
 			}, nil
 		}
 
@@ -127,7 +132,8 @@ func intercept(reqPaymentHash []byte, reqOutgoingAmountMsat uint64, reqOutgoingE
 		if err != nil {
 			log.Printf("sphinx.NewHopPayload(): %v", err)
 			return interceptResult{
-				action: INTERCEPT_FAIL_HTLC,
+				action:      INTERCEPT_FAIL_HTLC_WITH_CODE,
+				failureCode: FAILURE_TEMPORARY_CHANNEL_FAILURE,
 			}, nil
 		}
 
@@ -143,7 +149,8 @@ func intercept(reqPaymentHash []byte, reqOutgoingAmountMsat uint64, reqOutgoingE
 		if err != nil {
 			log.Printf("sphinx.NewOnionPacket(): %v", err)
 			return interceptResult{
-				action: INTERCEPT_FAIL_HTLC,
+				action:      INTERCEPT_FAIL_HTLC_WITH_CODE,
+				failureCode: FAILURE_TEMPORARY_CHANNEL_FAILURE,
 			}, nil
 		}
 		var onionBlob bytes.Buffer
@@ -151,7 +158,8 @@ func intercept(reqPaymentHash []byte, reqOutgoingAmountMsat uint64, reqOutgoingE
 		if err != nil {
 			log.Printf("sphinxPacket.Encode(): %v", err)
 			return interceptResult{
-				action: INTERCEPT_FAIL_HTLC,
+				action:      INTERCEPT_FAIL_HTLC_WITH_CODE,
+				failureCode: FAILURE_TEMPORARY_CHANNEL_FAILURE,
 			}, nil
 		}
 

--- a/itest/bob_offline_test.go
+++ b/itest/bob_offline_test.go
@@ -48,6 +48,7 @@ func testFailureBobOffline(p *testParams) {
 	})
 
 	// Kill the mobile client
+	log.Printf("Stopping breez client")
 	p.BreezClient().Stop()
 
 	// TODO: Fix race waiting for htlc interceptor.
@@ -58,4 +59,12 @@ func testFailureBobOffline(p *testParams) {
 	route := constructRoute(p.lsp.LightningNode(), p.BreezClient().Node(), channelId, lntest.NewShortChanIDFromString("1x0x0"), outerAmountMsat)
 	_, err := alice.PayViaRoute(outerAmountMsat, outerInvoice.paymentHash, outerInvoice.paymentSecret, route)
 	assert.Contains(p.t, err.Error(), "WIRE_TEMPORARY_CHANNEL_FAILURE")
+
+	log.Printf("Starting breez client again")
+	p.BreezClient().Start()
+	p.BreezClient().Node().ConnectPeer(p.lsp.LightningNode())
+
+	log.Printf("Alice paying again")
+	_, err = alice.PayViaRoute(outerAmountMsat, outerInvoice.paymentHash, outerInvoice.paymentSecret, route)
+	assert.Nil(p.t, err)
 }

--- a/itest/bob_offline_test.go
+++ b/itest/bob_offline_test.go
@@ -1,0 +1,61 @@
+package itest
+
+import (
+	"log"
+	"time"
+
+	"github.com/breez/lntest"
+	lspd "github.com/breez/lspd/rpc"
+	"github.com/stretchr/testify/assert"
+)
+
+func testFailureBobOffline(p *testParams) {
+	alice := lntest.NewClnNode(p.h, p.m, "Alice")
+	alice.Start()
+	alice.Fund(10000000)
+	p.lsp.LightningNode().Fund(10000000)
+
+	log.Print("Opening channel between Alice and the lsp")
+	channel := alice.OpenChannel(p.lsp.LightningNode(), &lntest.OpenChannelOptions{
+		AmountSat: publicChanAmount,
+	})
+	channelId := alice.WaitForChannelReady(channel)
+
+	log.Printf("Adding bob's invoices")
+	outerAmountMsat := uint64(2100000)
+	innerAmountMsat := calculateInnerAmountMsat(p.lsp, outerAmountMsat)
+	description := "Please pay me"
+	innerInvoice, outerInvoice := GenerateInvoices(p.BreezClient(),
+		generateInvoicesRequest{
+			innerAmountMsat: innerAmountMsat,
+			outerAmountMsat: outerAmountMsat,
+			description:     description,
+			lsp:             p.lsp,
+		})
+
+	log.Print("Connecting bob to lspd")
+	p.BreezClient().Node().ConnectPeer(p.lsp.LightningNode())
+
+	// NOTE: We pretend to be paying fees to the lsp, but actually we won't.
+	log.Printf("Registering payment with lsp")
+	pretendAmount := outerAmountMsat - 2000000
+	RegisterPayment(p.lsp, &lspd.PaymentInformation{
+		PaymentHash:        innerInvoice.paymentHash,
+		PaymentSecret:      innerInvoice.paymentSecret,
+		Destination:        p.BreezClient().Node().NodeId(),
+		IncomingAmountMsat: int64(outerAmountMsat),
+		OutgoingAmountMsat: int64(pretendAmount),
+	})
+
+	// Kill the mobile client
+	p.BreezClient().Stop()
+
+	// TODO: Fix race waiting for htlc interceptor.
+	log.Printf("Waiting %v to allow htlc interceptor to activate.", htlcInterceptorDelay)
+	<-time.After(htlcInterceptorDelay)
+
+	log.Printf("Alice paying")
+	route := constructRoute(p.lsp.LightningNode(), p.BreezClient().Node(), channelId, lntest.NewShortChanIDFromString("1x0x0"), outerAmountMsat)
+	_, err := alice.PayViaRoute(outerAmountMsat, outerInvoice.paymentHash, outerInvoice.paymentSecret, route)
+	assert.Contains(p.t, err.Error(), "WIRE_TEMPORARY_CHANNEL_FAILURE")
+}

--- a/itest/breez_client.go
+++ b/itest/breez_client.go
@@ -1,15 +1,9 @@
 package itest
 
 import (
-	"bufio"
 	"crypto/sha256"
-	"flag"
-	"fmt"
-	"os"
-	"path/filepath"
 
 	"github.com/breez/lntest"
-	"github.com/breez/lntest/lnd"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/btcsuite/btcd/chaincfg"
@@ -17,133 +11,12 @@ import (
 	"github.com/lightningnetwork/lnd/zpay32"
 )
 
-type breezClient struct {
-	name          string
-	harness       *lntest.TestHarness
-	lightningNode lntest.LightningNode
-	scriptDir     string
-}
-
-var pluginContent string = `#!/usr/bin/env python3
-"""Use the openchannel hook to selectively opt-into zeroconf
-"""
-
-from pyln.client import Plugin
-
-plugin = Plugin()
-
-
-@plugin.hook('openchannel')
-def on_openchannel(openchannel, plugin, **kwargs):
-	plugin.log(repr(openchannel))
-	mindepth = int(0)
-
-	plugin.log(f"This peer is in the zeroconf allowlist, setting mindepth={mindepth}")
-	return {'result': 'continue', 'mindepth': mindepth}
-
-plugin.run()
-`
-
-var pluginStartupContent string = `python3 -m venv %s > /dev/null 2>&1
-source %s > /dev/null 2>&1
-pip install pyln-client > /dev/null 2>&1
-python %s
-`
-
-func newClnBreezClient(h *lntest.TestHarness, m *lntest.Miner, name string) *breezClient {
-	scriptDir, err := os.MkdirTemp(h.Dir, name)
-	lntest.CheckError(h.T, err)
-	pythonFilePath := filepath.Join(scriptDir, "zero_conf_plugin.py")
-	pythonFile, err := os.OpenFile(pythonFilePath, os.O_CREATE|os.O_WRONLY, 0755)
-	lntest.CheckError(h.T, err)
-
-	pythonWriter := bufio.NewWriter(pythonFile)
-	_, err = pythonWriter.WriteString(pluginContent)
-	lntest.CheckError(h.T, err)
-
-	err = pythonWriter.Flush()
-	lntest.CheckError(h.T, err)
-	pythonFile.Close()
-
-	pluginFilePath := filepath.Join(scriptDir, "start_zero_conf_plugin.sh")
-	pluginFile, err := os.OpenFile(pluginFilePath, os.O_CREATE|os.O_WRONLY, 0755)
-	lntest.CheckError(h.T, err)
-
-	pluginWriter := bufio.NewWriter(pluginFile)
-	venvDir := filepath.Join(scriptDir, "venv")
-	activatePath := filepath.Join(venvDir, "bin", "activate")
-	_, err = pluginWriter.WriteString(fmt.Sprintf(pluginStartupContent, venvDir, activatePath, pythonFilePath))
-	lntest.CheckError(h.T, err)
-
-	err = pluginWriter.Flush()
-	lntest.CheckError(h.T, err)
-	pluginFile.Close()
-
-	node := lntest.NewClnNode(
-		h,
-		m,
-		name,
-		fmt.Sprintf("--plugin=%s", pluginFilePath),
-		// NOTE: max-concurrent-htlcs is 30 on mainnet by default. In cln V22.11
-		// there is a check for 'all dust' commitment transactions. The max
-		// concurrent HTLCs of both sides of the channel * dust limit must be
-		// lower than the channel capacity in order to open a zero conf zero
-		// reserve channel. Relevant code:
-		// https://github.com/ElementsProject/lightning/blob/774d16a72e125e4ae4e312b9e3307261983bec0e/openingd/openingd.c#L481-L520
-		"--max-concurrent-htlcs=30",
-	)
-
-	return &breezClient{
-		name:          name,
-		harness:       h,
-		lightningNode: node,
-		scriptDir:     scriptDir,
-	}
-}
-
-var lndMobileExecutable = flag.String(
-	"lndmobileexec", "", "full path to lnd mobile binary",
-)
-
-func newLndBreezClient(h *lntest.TestHarness, m *lntest.Miner, name string) *breezClient {
-	lnd := lntest.NewLndNodeFromBinary(h, m, name, *lndMobileExecutable,
-		"--protocol.zero-conf",
-		"--protocol.option-scid-alias",
-		"--bitcoin.defaultchanconfs=0",
-	)
-
-	go startChannelAcceptor(h, lnd)
-
-	return &breezClient{
-		name:          name,
-		harness:       h,
-		lightningNode: lnd,
-	}
-}
-
-func startChannelAcceptor(h *lntest.TestHarness, n *lntest.LndNode) error {
-	client, err := n.LightningClient().ChannelAcceptor(h.Ctx)
-	lntest.CheckError(h.T, err)
-
-	for {
-		request, err := client.Recv()
-		if err != nil {
-			return err
-		}
-
-		private := request.ChannelFlags&uint32(lnwire.FFAnnounceChannel) == 0
-		resp := &lnd.ChannelAcceptResponse{
-			PendingChanId: request.PendingChanId,
-			Accept:        private,
-		}
-		if request.WantsZeroConf {
-			resp.MinAcceptDepth = 0
-			resp.ZeroConf = true
-		}
-
-		err = client.Send(resp)
-		lntest.CheckError(h.T, err)
-	}
+type BreezClient interface {
+	Name() string
+	Harness() *lntest.TestHarness
+	Node() lntest.LightningNode
+	Start()
+	Stop() error
 }
 
 type generateInvoicesRequest struct {
@@ -160,20 +33,20 @@ type invoice struct {
 	paymentPreimage []byte
 }
 
-func (n *breezClient) GenerateInvoices(req generateInvoicesRequest) (invoice, invoice) {
+func GenerateInvoices(n BreezClient, req generateInvoicesRequest) (invoice, invoice) {
 	preimage, err := GenerateRandomBytes(32)
-	lntest.CheckError(n.harness.T, err)
+	lntest.CheckError(n.Harness().T, err)
 
 	lspNodeId, err := btcec.ParsePubKey(req.lsp.NodeId())
-	lntest.CheckError(n.harness.T, err)
+	lntest.CheckError(n.Harness().T, err)
 
-	innerInvoice := n.lightningNode.CreateBolt11Invoice(&lntest.CreateInvoiceOptions{
+	innerInvoice := n.Node().CreateBolt11Invoice(&lntest.CreateInvoiceOptions{
 		AmountMsat:  req.innerAmountMsat,
 		Description: &req.description,
 		Preimage:    &preimage,
 	})
 	outerInvoiceRaw, err := zpay32.Decode(innerInvoice.Bolt11, &chaincfg.RegressionNetParams)
-	lntest.CheckError(n.harness.T, err)
+	lntest.CheckError(n.Harness().T, err)
 
 	milliSat := lnwire.MilliSatoshi(req.outerAmountMsat)
 	outerInvoiceRaw.MilliSat = &milliSat
@@ -191,10 +64,10 @@ func (n *breezClient) GenerateInvoices(req generateInvoicesRequest) (invoice, in
 	outerInvoice, err := outerInvoiceRaw.Encode(zpay32.MessageSigner{
 		SignCompact: func(msg []byte) ([]byte, error) {
 			hash := sha256.Sum256(msg)
-			return ecdsa.SignCompact(n.lightningNode.PrivateKey(), hash[:], true)
+			return ecdsa.SignCompact(n.Node().PrivateKey(), hash[:], true)
 		},
 	})
-	lntest.CheckError(n.harness.T, err)
+	lntest.CheckError(n.Harness().T, err)
 
 	inner := invoice{
 		bolt11:          innerInvoice.Bolt11,

--- a/itest/cln_breez_client.go
+++ b/itest/cln_breez_client.go
@@ -1,0 +1,155 @@
+package itest
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/breez/lntest"
+)
+
+var pluginContent string = `#!/usr/bin/env python3
+"""Use the openchannel hook to selectively opt-into zeroconf
+"""
+
+from pyln.client import Plugin
+
+plugin = Plugin()
+
+
+@plugin.hook('openchannel')
+def on_openchannel(openchannel, plugin, **kwargs):
+	plugin.log(repr(openchannel))
+	mindepth = int(0)
+
+	plugin.log(f"This peer is in the zeroconf allowlist, setting mindepth={mindepth}")
+	return {'result': 'continue', 'mindepth': mindepth}
+
+plugin.run()
+`
+
+var pluginStartupContent string = `python3 -m venv %s > /dev/null 2>&1
+source %s > /dev/null 2>&1
+pip install pyln-client > /dev/null 2>&1
+python %s
+`
+
+type clnBreezClient struct {
+	name           string
+	scriptDir      string
+	pluginFilePath string
+	harness        *lntest.TestHarness
+	isInitialized  bool
+	node           *lntest.ClnNode
+	mtx            sync.Mutex
+}
+
+func newClnBreezClient(h *lntest.TestHarness, m *lntest.Miner, name string) BreezClient {
+	scriptDir := h.GetDirectory(name)
+	pluginFilePath := filepath.Join(scriptDir, "start_zero_conf_plugin.sh")
+	node := lntest.NewClnNode(
+		h,
+		m,
+		name,
+		fmt.Sprintf("--plugin=%s", pluginFilePath),
+		// NOTE: max-concurrent-htlcs is 30 on mainnet by default. In cln V22.11
+		// there is a check for 'all dust' commitment transactions. The max
+		// concurrent HTLCs of both sides of the channel * dust limit must be
+		// lower than the channel capacity in order to open a zero conf zero
+		// reserve channel. Relevant code:
+		// https://github.com/ElementsProject/lightning/blob/774d16a72e125e4ae4e312b9e3307261983bec0e/openingd/openingd.c#L481-L520
+		"--max-concurrent-htlcs=30",
+	)
+
+	return &clnBreezClient{
+		name:           name,
+		harness:        h,
+		node:           node,
+		scriptDir:      scriptDir,
+		pluginFilePath: pluginFilePath,
+	}
+}
+
+func (c *clnBreezClient) Name() string {
+	return c.name
+}
+
+func (c *clnBreezClient) Harness() *lntest.TestHarness {
+	return c.harness
+}
+
+func (c *clnBreezClient) Node() lntest.LightningNode {
+	return c.node
+}
+
+func (c *clnBreezClient) Start() {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	if !c.isInitialized {
+		c.initialize()
+		c.isInitialized = true
+	}
+
+	c.node.Start()
+}
+
+func (c *clnBreezClient) initialize() error {
+	var cleanups []*lntest.Cleanup
+
+	pythonFilePath := filepath.Join(c.scriptDir, "zero_conf_plugin.py")
+	pythonFile, err := os.OpenFile(pythonFilePath, os.O_CREATE|os.O_WRONLY, 0755)
+	if err != nil {
+		return fmt.Errorf("failed to create python file '%s': %v", pythonFilePath, err)
+	}
+	cleanups = append(cleanups, &lntest.Cleanup{
+		Name: fmt.Sprintf("%s: python file", c.name),
+		Fn:   pythonFile.Close,
+	})
+
+	pythonWriter := bufio.NewWriter(pythonFile)
+	_, err = pythonWriter.WriteString(pluginContent)
+	if err != nil {
+		lntest.PerformCleanup(cleanups)
+		return fmt.Errorf("failed to write content to python file '%s': %v", pythonFilePath, err)
+	}
+
+	err = pythonWriter.Flush()
+	if err != nil {
+		lntest.PerformCleanup(cleanups)
+		return fmt.Errorf("failed to flush python file '%s': %v", pythonFilePath, err)
+	}
+
+	pluginFile, err := os.OpenFile(c.pluginFilePath, os.O_CREATE|os.O_WRONLY, 0755)
+	if err != nil {
+		lntest.PerformCleanup(cleanups)
+		return fmt.Errorf("failed to create plugin file '%s': %v", c.pluginFilePath, err)
+	}
+	cleanups = append(cleanups, &lntest.Cleanup{
+		Name: fmt.Sprintf("%s: python file", c.name),
+		Fn:   pluginFile.Close,
+	})
+
+	pluginWriter := bufio.NewWriter(pluginFile)
+	venvDir := filepath.Join(c.scriptDir, "venv")
+	activatePath := filepath.Join(venvDir, "bin", "activate")
+	_, err = pluginWriter.WriteString(fmt.Sprintf(pluginStartupContent, venvDir, activatePath, pythonFilePath))
+	if err != nil {
+		lntest.PerformCleanup(cleanups)
+		return fmt.Errorf("failed to write content to plugin file '%s': %v", c.pluginFilePath, err)
+	}
+
+	err = pluginWriter.Flush()
+	if err != nil {
+		lntest.PerformCleanup(cleanups)
+		return fmt.Errorf("failed to flush plugin file '%s': %v", c.pluginFilePath, err)
+	}
+	lntest.PerformCleanup(cleanups)
+	return nil
+}
+
+func (c *clnBreezClient) Stop() error {
+	return c.node.Stop()
+}

--- a/itest/cln_lspd_node.go
+++ b/itest/cln_lspd_node.go
@@ -1,0 +1,133 @@
+package itest
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/breez/lntest"
+	lspd "github.com/breez/lspd/rpc"
+	"github.com/btcsuite/btcd/btcec/v2"
+	ecies "github.com/ecies/go/v2"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+type ClnLspNode struct {
+	harness       *lntest.TestHarness
+	lightningNode *lntest.ClnNode
+	lspBase       *lspBase
+	runtime       *clnLspNodeRuntime
+	isInitialized bool
+	mtx           sync.Mutex
+}
+
+type clnLspNodeRuntime struct {
+	rpc      lspd.ChannelOpenerClient
+	cleanups []*lntest.Cleanup
+}
+
+func NewClnLspdNode(h *lntest.TestHarness, m *lntest.Miner, name string) LspNode {
+	lspbase, err := newLspd(h, name, "RUN_CLN=true")
+	if err != nil {
+		h.T.Fatalf("failed to initialize lspd")
+	}
+
+	args := []string{
+		fmt.Sprintf("--plugin=%s", lspbase.scriptFilePath),
+		fmt.Sprintf("--fee-base=%d", lspBaseFeeMsat),
+		fmt.Sprintf("--fee-per-satoshi=%d", lspFeeRatePpm),
+		fmt.Sprintf("--cltv-delta=%d", lspCltvDelta),
+		"--max-concurrent-htlcs=30",
+		"--dev-allowdustreserve=true",
+	}
+	lightningNode := lntest.NewClnNode(h, m, name, args...)
+
+	lspNode := &ClnLspNode{
+		harness:       h,
+		lightningNode: lightningNode,
+		lspBase:       lspbase,
+	}
+
+	h.AddStoppable(lspNode)
+	return lspNode
+}
+
+func (c *ClnLspNode) Start() {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	var cleanups []*lntest.Cleanup
+	if !c.isInitialized {
+		err := c.lspBase.Initialize()
+		if err != nil {
+			c.harness.T.Fatalf("failed to initialize lsp: %v", err)
+		}
+		c.isInitialized = true
+		cleanups = append(cleanups, &lntest.Cleanup{
+			Name: fmt.Sprintf("%s: lsp base", c.lspBase.name),
+			Fn:   c.lspBase.Stop,
+		})
+	}
+
+	c.lightningNode.Start()
+	cleanups = append(cleanups, &lntest.Cleanup{
+		Name: fmt.Sprintf("%s: lightning node", c.lspBase.name),
+		Fn:   c.lightningNode.Stop,
+	})
+	conn, err := grpc.Dial(
+		c.lspBase.grpcAddress,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithPerRPCCredentials(&token{token: "hello"}),
+	)
+	if err != nil {
+		lntest.PerformCleanup(cleanups)
+		c.harness.T.Fatalf("%s: failed to create grpc connection: %v", c.lspBase.name, err)
+	}
+
+	client := lspd.NewChannelOpenerClient(conn)
+	c.runtime = &clnLspNodeRuntime{
+		rpc:      client,
+		cleanups: cleanups,
+	}
+}
+
+func (c *ClnLspNode) Stop() error {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	if c.runtime == nil {
+		return nil
+	}
+
+	lntest.PerformCleanup(c.runtime.cleanups)
+	c.runtime = nil
+	return nil
+}
+
+func (c *ClnLspNode) Harness() *lntest.TestHarness {
+	return c.harness
+}
+
+func (c *ClnLspNode) PublicKey() *btcec.PublicKey {
+	return c.lspBase.pubkey
+}
+
+func (c *ClnLspNode) EciesPublicKey() *ecies.PublicKey {
+	return c.lspBase.eciesPubkey
+}
+
+func (c *ClnLspNode) Rpc() lspd.ChannelOpenerClient {
+	return c.runtime.rpc
+}
+
+func (l *ClnLspNode) NodeId() []byte {
+	return l.lightningNode.NodeId()
+}
+
+func (l *ClnLspNode) LightningNode() lntest.LightningNode {
+	return l.lightningNode
+}
+
+func (l *ClnLspNode) SupportsChargingFees() bool {
+	return false
+}

--- a/itest/intercept_zero_conf_test.go
+++ b/itest/intercept_zero_conf_test.go
@@ -109,7 +109,8 @@ func testOpenZeroConfSingleHtlc(p *testParams) {
 	<-time.After(htlcInterceptorDelay)
 	log.Printf("Alice paying")
 	route := constructRoute(p.lsp.LightningNode(), p.BreezClient().Node(), channelId, lntest.NewShortChanIDFromString("1x0x0"), outerAmountMsat)
-	payResp := alice.PayViaRoute(outerAmountMsat, outerInvoice.paymentHash, outerInvoice.paymentSecret, route)
+	payResp, err := alice.PayViaRoute(outerAmountMsat, outerInvoice.paymentHash, outerInvoice.paymentSecret, route)
+	lntest.CheckError(p.t, err)
 	bobInvoice := p.BreezClient().Node().GetInvoice(payResp.PaymentHash)
 
 	assert.Equal(p.t, payResp.PaymentPreimage, bobInvoice.PaymentPreimage)

--- a/itest/lnd_breez_client.go
+++ b/itest/lnd_breez_client.go
@@ -1,0 +1,108 @@
+package itest
+
+import (
+	"context"
+	"flag"
+	"sync"
+
+	"github.com/breez/lntest"
+	"github.com/breez/lntest/lnd"
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+var lndMobileExecutable = flag.String(
+	"lndmobileexec", "", "full path to lnd mobile binary",
+)
+
+type lndBreezClient struct {
+	name    string
+	harness *lntest.TestHarness
+	node    *lntest.LndNode
+	cancel  context.CancelFunc
+	mtx     sync.Mutex
+}
+
+func newLndBreezClient(h *lntest.TestHarness, m *lntest.Miner, name string) BreezClient {
+	lnd := lntest.NewLndNodeFromBinary(h, m, name, *lndMobileExecutable,
+		"--protocol.zero-conf",
+		"--protocol.option-scid-alias",
+		"--bitcoin.defaultchanconfs=0",
+	)
+
+	c := &lndBreezClient{
+		name:    name,
+		harness: h,
+		node:    lnd,
+	}
+	h.AddStoppable(c)
+	return c
+}
+
+func (c *lndBreezClient) Name() string {
+	return c.name
+}
+
+func (c *lndBreezClient) Harness() *lntest.TestHarness {
+	return c.harness
+}
+
+func (c *lndBreezClient) Node() lntest.LightningNode {
+	return c.node
+}
+
+func (c *lndBreezClient) Start() {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	if c.node.IsStarted() {
+		return
+	}
+
+	c.node.Start()
+
+	ctx, cancel := context.WithCancel(c.harness.Ctx)
+	c.cancel = cancel
+	go c.startChannelAcceptor(ctx)
+}
+
+func (c *lndBreezClient) Stop() error {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	// Stop the channel acceptor
+	if c.cancel != nil {
+		c.cancel()
+		c.cancel = nil
+	}
+
+	return c.node.Stop()
+}
+
+func (c *lndBreezClient) startChannelAcceptor(ctx context.Context) error {
+	client, err := c.node.LightningClient().ChannelAcceptor(ctx)
+	if err != nil {
+		c.harness.T.Fatalf("%s: failed to create channel acceptor: %v", c.name, err)
+	}
+
+	for {
+		request, err := client.Recv()
+		if err != nil {
+			return err
+		}
+
+		private := request.ChannelFlags&uint32(lnwire.FFAnnounceChannel) == 0
+		resp := &lnd.ChannelAcceptResponse{
+			PendingChanId: request.PendingChanId,
+			Accept:        private,
+		}
+		if request.WantsZeroConf {
+			resp.MinAcceptDepth = 0
+			resp.ZeroConf = true
+		}
+
+		err = client.Send(resp)
+		if err != nil {
+			c.harness.T.Fatalf("%s: failed to send acceptor response: %v", c.name, err)
+		}
+	}
+}

--- a/itest/lnd_lspd_node.go
+++ b/itest/lnd_lspd_node.go
@@ -1,0 +1,230 @@
+package itest
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+
+	"github.com/breez/lntest"
+	lspd "github.com/breez/lspd/rpc"
+	"github.com/btcsuite/btcd/btcec/v2"
+	ecies "github.com/ecies/go/v2"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+type LndLspNode struct {
+	harness       *lntest.TestHarness
+	lightningNode *lntest.LndNode
+	logFilePath   string
+	isInitialized bool
+	lspBase       *lspBase
+	runtime       *lndLspNodeRuntime
+	mtx           sync.Mutex
+}
+
+type lndLspNodeRuntime struct {
+	logFile  *os.File
+	cmd      *exec.Cmd
+	rpc      lspd.ChannelOpenerClient
+	cleanups []*lntest.Cleanup
+}
+
+func NewLndLspdNode(h *lntest.TestHarness, m *lntest.Miner, name string) LspNode {
+	args := []string{
+		"--protocol.zero-conf",
+		"--protocol.option-scid-alias",
+		"--requireinterceptor",
+		"--bitcoin.defaultchanconfs=0",
+		fmt.Sprintf("--bitcoin.chanreservescript=\"0 if (chanAmt != %d) else chanAmt/100\"", publicChanAmount),
+		fmt.Sprintf("--bitcoin.basefee=%d", lspBaseFeeMsat),
+		fmt.Sprintf("--bitcoin.feerate=%d", lspFeeRatePpm),
+		fmt.Sprintf("--bitcoin.timelockdelta=%d", lspCltvDelta),
+	}
+
+	lightningNode := lntest.NewLndNode(h, m, name, args...)
+	tlsCert := strings.Replace(string(lightningNode.TlsCert()), "\n", "\\n", -1)
+	lspBase, err := newLspd(h, name,
+		"RUN_LND=true",
+		fmt.Sprintf("LND_CERT=\"%s\"", tlsCert),
+		fmt.Sprintf("LND_ADDRESS=%s", lightningNode.GrpcHost()),
+		fmt.Sprintf("LND_MACAROON_HEX=%x", lightningNode.Macaroon()),
+	)
+	if err != nil {
+		h.T.Fatalf("failed to initialize lspd")
+	}
+	scriptDir := filepath.Dir(lspBase.scriptFilePath)
+	logFilePath := filepath.Join(scriptDir, "lspd.log")
+	h.RegisterLogfile(logFilePath, fmt.Sprintf("lspd-%s", name))
+
+	lspNode := &LndLspNode{
+		harness:       h,
+		lightningNode: lightningNode,
+		logFilePath:   logFilePath,
+		lspBase:       lspBase,
+	}
+
+	h.AddStoppable(lspNode)
+	return lspNode
+}
+
+func (c *LndLspNode) Start() {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	var cleanups []*lntest.Cleanup
+	wasInitialized := c.isInitialized
+	if !c.isInitialized {
+		err := c.lspBase.Initialize()
+		if err != nil {
+			c.harness.T.Fatalf("failed to initialize lsp: %v", err)
+		}
+		c.isInitialized = true
+		cleanups = append(cleanups, &lntest.Cleanup{
+			Name: fmt.Sprintf("%s: lsp base", c.lspBase.name),
+			Fn:   c.lspBase.Stop,
+		})
+	}
+
+	c.lightningNode.Start()
+	cleanups = append(cleanups, &lntest.Cleanup{
+		Name: fmt.Sprintf("%s: lsp lightning node", c.lspBase.name),
+		Fn:   c.lightningNode.Stop,
+	})
+
+	if !wasInitialized {
+		scriptFile, err := os.ReadFile(c.lspBase.scriptFilePath)
+		if err != nil {
+			lntest.PerformCleanup(cleanups)
+			c.harness.T.Fatalf("failed to open scriptfile '%s': %v", c.lspBase.scriptFilePath, err)
+		}
+
+		err = os.Remove(c.lspBase.scriptFilePath)
+		if err != nil {
+			lntest.PerformCleanup(cleanups)
+			c.harness.T.Fatalf("failed to remove scriptfile '%s': %v", c.lspBase.scriptFilePath, err)
+		}
+
+		split := strings.Split(string(scriptFile), "\n")
+		for i, s := range split {
+			if strings.HasPrefix(s, "export LND_CERT") {
+				tlsCert := strings.Replace(string(c.lightningNode.TlsCert()), "\n", "\\n", -1)
+				split[i] = fmt.Sprintf("export LND_CERT=\"%s\"", tlsCert)
+			}
+
+			if strings.HasPrefix(s, "export LND_MACAROON_HEX") {
+				split[i] = fmt.Sprintf("export LND_MACAROON_HEX=%x", c.lightningNode.Macaroon())
+			}
+		}
+		newContent := strings.Join(split, "\n")
+		err = os.WriteFile(c.lspBase.scriptFilePath, []byte(newContent), 0755)
+		if err != nil {
+			lntest.PerformCleanup(cleanups)
+			c.harness.T.Fatalf("failed to rewrite scriptfile '%s': %v", c.lspBase.scriptFilePath, err)
+		}
+	}
+
+	cmd := exec.CommandContext(c.harness.Ctx, c.lspBase.scriptFilePath)
+	logFile, err := os.Create(c.logFilePath)
+	if err != nil {
+		lntest.PerformCleanup(cleanups)
+		c.harness.T.Fatalf("failed create lsp logfile: %v", err)
+	}
+	cleanups = append(cleanups, &lntest.Cleanup{
+		Name: fmt.Sprintf("%s: logfile", c.lspBase.name),
+		Fn:   logFile.Close,
+	})
+
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+
+	log.Printf("%s: starting lspd %s", c.lspBase.name, c.lspBase.scriptFilePath)
+	err = cmd.Start()
+	if err != nil {
+		lntest.PerformCleanup(cleanups)
+		c.harness.T.Fatalf("failed to start lspd: %v", err)
+	}
+	cleanups = append(cleanups, &lntest.Cleanup{
+		Name: fmt.Sprintf("%s: cmd", c.lspBase.name),
+		Fn: func() error {
+			proc := cmd.Process
+			if proc != nil {
+				if runtime.GOOS == "windows" {
+					return proc.Signal(os.Kill)
+				}
+
+				return proc.Signal(os.Interrupt)
+			}
+
+			return nil
+		},
+	})
+
+	conn, err := grpc.Dial(
+		c.lspBase.grpcAddress,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithPerRPCCredentials(&token{token: "hello"}),
+	)
+	if err != nil {
+		lntest.PerformCleanup(cleanups)
+		c.harness.T.Fatalf("failed to create grpc connection: %v", err)
+	}
+	cleanups = append(cleanups, &lntest.Cleanup{
+		Name: fmt.Sprintf("%s: grpc conn", c.lspBase.name),
+		Fn:   conn.Close,
+	})
+
+	client := lspd.NewChannelOpenerClient(conn)
+	c.runtime = &lndLspNodeRuntime{
+		logFile:  logFile,
+		cmd:      cmd,
+		rpc:      client,
+		cleanups: cleanups,
+	}
+}
+
+func (c *LndLspNode) Stop() error {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	if c.runtime == nil {
+		return nil
+	}
+
+	lntest.PerformCleanup(c.runtime.cleanups)
+	c.runtime = nil
+	return nil
+}
+
+func (c *LndLspNode) Harness() *lntest.TestHarness {
+	return c.harness
+}
+
+func (c *LndLspNode) PublicKey() *btcec.PublicKey {
+	return c.lspBase.pubkey
+}
+
+func (c *LndLspNode) EciesPublicKey() *ecies.PublicKey {
+	return c.lspBase.eciesPubkey
+}
+
+func (c *LndLspNode) Rpc() lspd.ChannelOpenerClient {
+	return c.runtime.rpc
+}
+
+func (l *LndLspNode) SupportsChargingFees() bool {
+	return true
+}
+
+func (l *LndLspNode) NodeId() []byte {
+	return l.lightningNode.NodeId()
+}
+
+func (l *LndLspNode) LightningNode() lntest.LightningNode {
+	return l.lightningNode
+}

--- a/itest/lspd_test.go
+++ b/itest/lspd_test.go
@@ -3,7 +3,6 @@ package itest
 import (
 	"fmt"
 	"log"
-	"sync"
 	"testing"
 	"time"
 
@@ -51,18 +50,8 @@ func runTest(t *testing.T, testCase *testCase, prefix string, nodesFunc func(h *
 	miner.Start()
 	log.Printf("Creating lsp")
 	lsp, c := nodesFunc(h, miner)
-	var wg sync.WaitGroup
-	wg.Add(2)
-	go func() {
-		lsp.Start()
-		wg.Done()
-	}()
-
-	go func() {
-		c.Start()
-		wg.Done()
-	}()
-	wg.Wait()
+	lsp.Start()
+	c.Start()
 	log.Printf("Run testcase")
 	testCase.test(&testParams{
 		t:   t,
@@ -91,5 +80,9 @@ var allTestCases = []*testCase{
 	{
 		name: "testZeroReserve",
 		test: testZeroReserve,
+	},
+	{
+		name: "testFailureBobOffline",
+		test: testFailureBobOffline,
 	},
 }

--- a/itest/test_params.go
+++ b/itest/test_params.go
@@ -10,7 +10,7 @@ type testParams struct {
 	t   *testing.T
 	h   *lntest.TestHarness
 	m   *lntest.Miner
-	c   *breezClient
+	c   BreezClient
 	lsp LspNode
 }
 
@@ -30,6 +30,6 @@ func (h *testParams) Harness() *lntest.TestHarness {
 	return h.h
 }
 
-func (h *testParams) BreezClient() *breezClient {
+func (h *testParams) BreezClient() BreezClient {
 	return h.c
 }

--- a/itest/zero_reserve_test.go
+++ b/itest/zero_reserve_test.go
@@ -11,6 +11,7 @@ import (
 
 func testZeroReserve(p *testParams) {
 	alice := lntest.NewClnNode(p.h, p.m, "Alice")
+	alice.Start()
 	alice.Fund(10000000)
 	p.lsp.LightningNode().Fund(10000000)
 
@@ -24,15 +25,16 @@ func testZeroReserve(p *testParams) {
 	outerAmountMsat := uint64(2100000)
 	innerAmountMsat := calculateInnerAmountMsat(p.lsp, outerAmountMsat)
 	description := "Please pay me"
-	innerInvoice, outerInvoice := p.BreezClient().GenerateInvoices(generateInvoicesRequest{
-		innerAmountMsat: innerAmountMsat,
-		outerAmountMsat: outerAmountMsat,
-		description:     description,
-		lsp:             p.lsp,
-	})
+	innerInvoice, outerInvoice := GenerateInvoices(p.BreezClient(),
+		generateInvoicesRequest{
+			innerAmountMsat: innerAmountMsat,
+			outerAmountMsat: outerAmountMsat,
+			description:     description,
+			lsp:             p.lsp,
+		})
 
 	log.Print("Connecting bob to lspd")
-	p.BreezClient().lightningNode.ConnectPeer(p.lsp.LightningNode())
+	p.BreezClient().Node().ConnectPeer(p.lsp.LightningNode())
 
 	// NOTE: We pretend to be paying fees to the lsp, but actually we won't.
 	log.Printf("Registering payment with lsp")
@@ -40,7 +42,7 @@ func testZeroReserve(p *testParams) {
 	RegisterPayment(p.lsp, &lspd.PaymentInformation{
 		PaymentHash:        innerInvoice.paymentHash,
 		PaymentSecret:      innerInvoice.paymentSecret,
-		Destination:        p.BreezClient().lightningNode.NodeId(),
+		Destination:        p.BreezClient().Node().NodeId(),
 		IncomingAmountMsat: int64(outerAmountMsat),
 		OutgoingAmountMsat: int64(pretendAmount),
 	})
@@ -49,11 +51,11 @@ func testZeroReserve(p *testParams) {
 	log.Printf("Waiting %v to allow htlc interceptor to activate.", htlcInterceptorDelay)
 	<-time.After(htlcInterceptorDelay)
 	log.Printf("Alice paying")
-	route := constructRoute(p.lsp.LightningNode(), p.BreezClient().lightningNode, channelId, lntest.NewShortChanIDFromString("1x0x0"), outerAmountMsat)
+	route := constructRoute(p.lsp.LightningNode(), p.BreezClient().Node(), channelId, lntest.NewShortChanIDFromString("1x0x0"), outerAmountMsat)
 	alice.PayViaRoute(outerAmountMsat, outerInvoice.paymentHash, outerInvoice.paymentSecret, route)
 
 	// Make sure balance is correct
-	chans := p.BreezClient().lightningNode.GetChannels()
+	chans := p.BreezClient().Node().GetChannels()
 	assert.Len(p.t, chans, 1)
 
 	c := chans[0]


### PR DESCRIPTION
In order to test the offline Breez client, some things had to be refactored to allow start/stop of nodes and lspd. Testing this I found a bug where the CLN lspd would always return TEMPORARY_NODE_FAILURE if lspd decides to fail the HTLC. This PR fixes that too.