### PR TITLE
Probing

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ In order to run the integration tests, you need:
 - Docker running
 - python3 installed
 - A development build of lightningd v22.11
-- lnd v0.15.4 lsp version https://github.com/breez/lnd/tree/breez-node-v0.15.4
+- lnd v0.15.4 lsp version https://github.com/breez/lnd/commit/6ee6b89e3a4e3f2776643a75a9100d13a2090725
 - lnd v0.15.3 breez client version https://github.com/breez/lnd/commit/e1570b327b5de52d03817ad516d0bdfa71797c64
 - bitcoind (tested with v23.0)
 - bitcoin-cli (tested with v23.0)

--- a/cln_interceptor.go
+++ b/cln_interceptor.go
@@ -182,7 +182,7 @@ func (i *ClnHtlcInterceptor) mapFailureCode(original interceptFailureCode) strin
 	case FAILURE_TEMPORARY_NODE_FAILURE:
 		return "2002"
 	case FAILURE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS:
-		return "4015"
+		return "400F"
 	default:
 		log.Printf("Unknown failure code %v, default to temporary channel failure.", original)
 		return "1007" // temporary channel failure

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/aws/aws-sdk-go v1.30.20
-	github.com/breez/lntest v0.0.15
+	github.com/breez/lntest v0.0.16
 	github.com/btcsuite/btcd v0.23.3
 	github.com/btcsuite/btcd/btcec/v2 v2.2.1
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1

--- a/intercept.go
+++ b/intercept.go
@@ -77,7 +77,7 @@ func intercept(reqPaymentHash []byte, reqOutgoingAmountMsat uint64, reqOutgoingE
 			} else { //probing
 				failureCode := FAILURE_TEMPORARY_CHANNEL_FAILURE
 				isConnected, _ := client.IsConnected(destination)
-				if err != nil || !isConnected {
+				if isConnected {
 					failureCode = FAILURE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS
 				}
 

--- a/intercept.go
+++ b/intercept.go
@@ -30,7 +30,7 @@ type interceptFailureCode uint16
 var (
 	FAILURE_TEMPORARY_CHANNEL_FAILURE            interceptFailureCode = 0x1007
 	FAILURE_TEMPORARY_NODE_FAILURE               interceptFailureCode = 0x2002
-	FAILURE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS interceptFailureCode = 0x4015
+	FAILURE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS interceptFailureCode = 0x400F
 )
 
 var payHashGroup singleflight.Group

--- a/intercept.go
+++ b/intercept.go
@@ -75,15 +75,9 @@ func intercept(reqPaymentHash []byte, reqOutgoingAmountMsat uint64, reqOutgoingE
 					}, nil
 				}
 			} else { //probing
-				failureCode := FAILURE_TEMPORARY_CHANNEL_FAILURE
-				isConnected, _ := client.IsConnected(destination)
-				if isConnected {
-					failureCode = FAILURE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS
-				}
-
 				return interceptResult{
 					action:      INTERCEPT_FAIL_HTLC_WITH_CODE,
-					failureCode: failureCode,
+					failureCode: FAILURE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS,
 				}, nil
 			}
 		}

--- a/itest/lspd_test.go
+++ b/itest/lspd_test.go
@@ -93,4 +93,8 @@ var allTestCases = []*testCase{
 		name: "testRegularForward",
 		test: testRegularForward,
 	},
+	{
+		name: "testProbing",
+		test: testProbing,
+	},
 }

--- a/itest/probing_test.go
+++ b/itest/probing_test.go
@@ -59,8 +59,8 @@ func testProbing(p *testParams) {
 	route := constructRoute(p.lsp.LightningNode(), p.BreezClient().Node(), channelId, lntest.NewShortChanIDFromString("1x0x0"), outerAmountMsat)
 	_, err := alice.PayViaRoute(outerAmountMsat, fakePaymentHash, outerInvoice.paymentSecret, route)
 
-	// Expect temporary channel failure if the peer is online
-	assert.Contains(p.t, err.Error(), "WIRE_TEMPORARY_CHANNEL_FAILURE")
+	// Expect incorrect or unknown payment details if the peer is online
+	assert.Contains(p.t, err.Error(), "WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS")
 
 	// Kill the mobile client
 	log.Printf("Stopping breez client")
@@ -69,6 +69,6 @@ func testProbing(p *testParams) {
 	log.Printf("Alice paying with fake payment hash with Bob offline %x", fakePaymentHash)
 	_, err = alice.PayViaRoute(outerAmountMsat, fakePaymentHash, outerInvoice.paymentSecret, route)
 
-	// Expect incorrect or unknown payment details if the peer is offline
-	assert.Contains(p.t, err.Error(), "WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS")
+	// Expect temporary channel failure if the peer is offline
+	assert.Contains(p.t, err.Error(), "WIRE_TEMPORARY_CHANNEL_FAILURE")
 }

--- a/itest/probing_test.go
+++ b/itest/probing_test.go
@@ -70,5 +70,5 @@ func testProbing(p *testParams) {
 	_, err = alice.PayViaRoute(outerAmountMsat, fakePaymentHash, outerInvoice.paymentSecret, route)
 
 	// Expect temporary channel failure if the peer is offline
-	assert.Contains(p.t, err.Error(), "WIRE_TEMPORARY_CHANNEL_FAILURE")
+	assert.Contains(p.t, err.Error(), "WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS")
 }

--- a/itest/probing_test.go
+++ b/itest/probing_test.go
@@ -1,0 +1,74 @@
+package itest
+
+import (
+	"crypto/sha256"
+	"log"
+	"time"
+
+	"github.com/breez/lntest"
+	lspd "github.com/breez/lspd/rpc"
+	"github.com/stretchr/testify/assert"
+)
+
+func testProbing(p *testParams) {
+	alice := lntest.NewClnNode(p.h, p.m, "Alice")
+	alice.Start()
+	alice.Fund(10000000)
+	p.lsp.LightningNode().Fund(10000000)
+
+	log.Print("Opening channel between Alice and the lsp")
+	channel := alice.OpenChannel(p.lsp.LightningNode(), &lntest.OpenChannelOptions{
+		AmountSat: publicChanAmount,
+	})
+	channelId := alice.WaitForChannelReady(channel)
+
+	log.Printf("Adding bob's invoices")
+	outerAmountMsat := uint64(2100000)
+	innerAmountMsat, lspAmountMsat := calculateInnerAmountMsat(p.lsp, outerAmountMsat)
+	description := "Please pay me"
+	innerInvoice, outerInvoice := GenerateInvoices(p.BreezClient(),
+		generateInvoicesRequest{
+			innerAmountMsat: innerAmountMsat,
+			outerAmountMsat: outerAmountMsat,
+			description:     description,
+			lsp:             p.lsp,
+		})
+
+	log.Print("Connecting bob to lspd")
+	p.BreezClient().Node().ConnectPeer(p.lsp.LightningNode())
+
+	log.Printf("Registering payment with lsp")
+	RegisterPayment(p.lsp, &lspd.PaymentInformation{
+		PaymentHash:        innerInvoice.paymentHash,
+		PaymentSecret:      innerInvoice.paymentSecret,
+		Destination:        p.BreezClient().Node().NodeId(),
+		IncomingAmountMsat: int64(outerAmountMsat),
+		OutgoingAmountMsat: int64(lspAmountMsat),
+	})
+
+	// TODO: Fix race waiting for htlc interceptor.
+	log.Printf("Waiting %v to allow htlc interceptor to activate.", htlcInterceptorDelay)
+	<-time.After(htlcInterceptorDelay)
+
+	h := sha256.New()
+	_, _ = h.Write([]byte("probing-01:"))
+	_, _ = h.Write(outerInvoice.paymentHash)
+	fakePaymentHash := h.Sum(nil)
+
+	log.Printf("Alice paying with fake payment hash with Bob online %x", fakePaymentHash)
+	route := constructRoute(p.lsp.LightningNode(), p.BreezClient().Node(), channelId, lntest.NewShortChanIDFromString("1x0x0"), outerAmountMsat)
+	_, err := alice.PayViaRoute(outerAmountMsat, fakePaymentHash, outerInvoice.paymentSecret, route)
+
+	// Expect temporary channel failure if the peer is online
+	assert.Contains(p.t, err.Error(), "WIRE_TEMPORARY_CHANNEL_FAILURE")
+
+	// Kill the mobile client
+	log.Printf("Stopping breez client")
+	p.BreezClient().Stop()
+
+	log.Printf("Alice paying with fake payment hash with Bob offline %x", fakePaymentHash)
+	_, err = alice.PayViaRoute(outerAmountMsat, fakePaymentHash, outerInvoice.paymentSecret, route)
+
+	// Expect incorrect or unknown payment details if the peer is offline
+	assert.Contains(p.t, err.Error(), "WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS")
+}

--- a/itest/regular_forward_test.go
+++ b/itest/regular_forward_test.go
@@ -40,7 +40,8 @@ func testRegularForward(p *testParams) {
 	log.Printf("Adding bob's invoice")
 	amountMsat := uint64(2100000)
 	bobInvoice := p.BreezClient().Node().CreateBolt11Invoice(&lntest.CreateInvoiceOptions{
-		AmountMsat: amountMsat,
+		AmountMsat:      amountMsat,
+		IncludeHopHints: true,
 	})
 	log.Printf(bobInvoice.Bolt11)
 


### PR DESCRIPTION
- Add a test that asserts HTLCs with a `probing-01:` prefix on the payment hash fail with incorrect or unknown payment details.
- Fix that probing support in both CLN and LND

Note that the LSP LND node needs to be upgraded to include this PR https://github.com/breez/lnd/pull/5 in order for LND to accept returning  incorrect or unknown payment details from an intermediate node.