### PR TITLE
Multiple nodes

### DIFF
--- a/cln_client.go
+++ b/cln_client.go
@@ -4,7 +4,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log"
-	"os"
+	"path/filepath"
 
 	"github.com/breez/lspd/basetypes"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -24,15 +24,22 @@ var (
 	CLOSED_STATUSES  = []string{"CLOSED"}
 )
 
-func NewClnClient() *ClnClient {
-	rpcFile := os.Getenv("CLN_SOCKET_NAME")
-	lightningDir := os.Getenv("CLN_SOCKET_DIR")
+func NewClnClient(socketPath string) (*ClnClient, error) {
+	rpcFile := filepath.Base(socketPath)
+	if rpcFile == "" || rpcFile == "." {
+		return nil, fmt.Errorf("invalid socketPath '%s'", socketPath)
+	}
+	lightningDir := filepath.Dir(socketPath)
+	if lightningDir == "" || lightningDir == "." {
+		return nil, fmt.Errorf("invalid socketPath '%s'", socketPath)
+	}
+
 	client := glightning.NewLightning()
 	client.SetTimeout(60)
 	client.StartUp(rpcFile, lightningDir)
 	return &ClnClient{
 		client: client,
-	}
+	}, nil
 }
 
 func (c *ClnClient) GetInfo() (*GetInfoResult, error) {

--- a/cln_plugin/cln_plugin.go
+++ b/cln_plugin/cln_plugin.go
@@ -1,3 +1,7 @@
+// The code in this plugin is highly inspired by and sometimes copied from
+// github.com/niftynei/glightning. Therefore pieces of this code are subject
+// to Copyright Lisa Neigut (Blockstream) 2019.
+
 package cln_plugin
 
 import (

--- a/config.go
+++ b/config.go
@@ -1,0 +1,32 @@
+package main
+
+type NodeConfig struct {
+	LspdPrivateKey            string     `json:"lspdPrivateKey"`
+	Token                     string     `json:"token"`
+	Host                      string     `json:"host"`
+	PublicChannelAmount       int64      `json:"publicChannelAmount,string"`
+	ChannelAmount             uint64     `json:"channelAmount,string"`
+	ChannelPrivate            bool       `json:"channelPrivate"`
+	TargetConf                uint32     `json:"targetConf,string"`
+	MinHtlcMsat               uint64     `json:"minHtlcMsat,string"`
+	BaseFeeMsat               uint64     `json:"baseFeeMsat,string"`
+	FeeRate                   float64    `json:"feeRate,string"`
+	TimeLockDelta             uint32     `json:"timeLockDelta,string"`
+	ChannelFeePermyriad       int64      `json:"channelFeePermyriad,string"`
+	ChannelMinimumFeeMsat     int64      `json:"channelMinimumFeeMsat,string"`
+	AdditionalChannelCapacity int64      `json:"additionalChannelCapacity,string"`
+	MaxInactiveDuration       uint64     `json:"maxInactiveDuration,string"`
+	Lnd                       *LndConfig `json:"lnd,omitempty"`
+	Cln                       *ClnConfig `json:"cln,omitempty"`
+}
+
+type LndConfig struct {
+	Address  string `json:"address"`
+	Cert     string `json:"cert"`
+	Macaroon string `json:"macaroon"`
+}
+
+type ClnConfig struct {
+	PluginAddress string `json:"pluginAddress"`
+	SocketPath    string `json:"socketPath"`
+}

--- a/db.go
+++ b/db.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log"
-	"os"
 	"time"
 
 	"github.com/btcsuite/btcd/wire"
@@ -18,11 +17,11 @@ var (
 	pgxPool *pgxpool.Pool
 )
 
-func pgConnect() error {
+func pgConnect(databaseUrl string) error {
 	var err error
-	pgxPool, err = pgxpool.Connect(context.Background(), os.Getenv("DATABASE_URL"))
+	pgxPool, err = pgxpool.Connect(context.Background(), databaseUrl)
 	if err != nil {
-		return fmt.Errorf("pgxpool.Connect(%v): %w", os.Getenv("DATABASE_URL"), err)
+		return fmt.Errorf("pgxpool.Connect(%v): %w", databaseUrl, err)
 	}
 	return nil
 }

--- a/htlc_interceptor.go
+++ b/htlc_interceptor.go
@@ -3,5 +3,5 @@ package main
 type HtlcInterceptor interface {
 	Start() error
 	Stop() error
-	WaitStarted() LightningClient
+	WaitStarted()
 }

--- a/itest/cln_lspd_node.go
+++ b/itest/cln_lspd_node.go
@@ -59,12 +59,12 @@ func NewClnLspdNode(h *lntest.TestHarness, m *lntest.Miner, name string) LspNode
 		"--dev-allowdustreserve=true",
 	}
 	lightningNode := lntest.NewClnNode(h, m, name, args...)
-	lspbase, err := newLspd(h, name,
-		"RUN_CLN=true",
-		fmt.Sprintf("CLN_PLUGIN_ADDRESS=%s", pluginAddress),
-		fmt.Sprintf("CLN_SOCKET_DIR=%s", lightningNode.SocketDir()),
-		fmt.Sprintf("CLN_SOCKET_NAME=%s", lightningNode.SocketFile()),
+	cln := fmt.Sprintf(
+		`{ "pluginAddress": "%s", "socketPath": "%s" }`,
+		pluginAddress,
+		filepath.Join(lightningNode.SocketDir(), lightningNode.SocketFile()),
 	)
+	lspbase, err := newLspd(h, name, nil, &cln)
 	if err != nil {
 		h.T.Fatalf("failed to initialize lspd")
 	}

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -21,59 +22,79 @@ func main() {
 		return
 	}
 
-	err := pgConnect()
+	n := os.Getenv("NODES")
+	var nodes []*NodeConfig
+	err := json.Unmarshal([]byte(n), &nodes)
+	if err != nil {
+		log.Fatalf("failed to unmarshal NODES env: %v", err)
+	}
+
+	if len(nodes) == 0 {
+		log.Fatalf("need at least one node configured in NODES.")
+	}
+
+	var interceptors []HtlcInterceptor
+	for _, node := range nodes {
+		var interceptor HtlcInterceptor
+		if node.Lnd != nil {
+			interceptor, err = NewLndHtlcInterceptor(node)
+			if err != nil {
+				log.Fatalf("failed to initialize LND interceptor: %v", err)
+			}
+		}
+
+		if node.Cln != nil {
+			interceptor, err = NewClnHtlcInterceptor(node)
+			if err != nil {
+				log.Fatalf("failed to initialize CLN interceptor: %v", err)
+			}
+		}
+
+		if interceptor == nil {
+			log.Fatalf("node has to be either cln or lnd")
+		}
+
+		interceptors = append(interceptors, interceptor)
+	}
+
+	address := os.Getenv("LISTEN_ADDRESS")
+	certMagicDomain := os.Getenv("CERTMAGIC_DOMAIN")
+	s, err := NewGrpcServer(nodes, address, certMagicDomain)
+	if err != nil {
+		log.Fatalf("failed to initialize grpc server: %v", err)
+	}
+
+	databaseUrl := os.Getenv("DATABASE_URL")
+	err = pgConnect(databaseUrl)
 	if err != nil {
 		log.Fatalf("pgConnect() error: %v", err)
 	}
 
-	runCln := os.Getenv("RUN_CLN") == "true"
-	runLnd := os.Getenv("RUN_LND") == "true"
-
-	if runCln && runLnd {
-		log.Fatalf("One of RUN_CLN or RUN_LND must be true, not both.")
-	}
-
-	if !runCln && !runLnd {
-		log.Fatalf("Either RUN_CLN or RUN_LND must be true.")
-	}
-
-	var interceptor HtlcInterceptor
-	if runCln {
-		interceptor = NewClnHtlcInterceptor()
-	}
-
-	if runLnd {
-		interceptor = NewLndHtlcInterceptor()
-	}
-
-	s := NewGrpcServer()
-
 	var wg sync.WaitGroup
-	wg.Add(2)
+	wg.Add(len(interceptors) + 1)
 
-	go func() {
-		err := interceptor.Start()
-		if err == nil {
-			log.Printf("Interceptor stopped.")
-		} else {
-			log.Printf("FATAL. Interceptor stopped with error: %v", err)
+	stopInterceptors := func() {
+		for _, interceptor := range interceptors {
+			interceptor.Stop()
 		}
-		s.Stop()
-		wg.Done()
-	}()
-
-	client = interceptor.WaitStarted()
-	info, err := client.GetInfo()
-	if err != nil {
-		log.Fatalf("client.GetInfo() error: %v", err)
 	}
-	log.Printf("Connected to node '%s', alias '%s'", info.Pubkey, info.Alias)
 
-	if nodeName == "" {
-		nodeName = info.Alias
-	}
-	if nodePubkey == "" {
-		nodePubkey = info.Pubkey
+	for _, interceptor := range interceptors {
+		i := interceptor
+		go func() {
+			err := i.Start()
+			if err == nil {
+				log.Printf("Interceptor stopped.")
+			} else {
+				log.Printf("FATAL. Interceptor stopped with error: %v", err)
+			}
+
+			wg.Done()
+
+			// If any interceptor stops, stop everything, so we're able to restart using systemd.
+			s.Stop()
+			stopInterceptors()
+		}()
 	}
 
 	go func() {
@@ -84,8 +105,10 @@ func main() {
 			log.Printf("FATAL. GRPC server stopped with error: %v", err)
 		}
 
-		interceptor.Stop()
 		wg.Done()
+
+		// If the server stops, stop everything else, so we're able to restart using systemd.
+		stopInterceptors()
 	}()
 
 	c := make(chan os.Signal, 1)
@@ -93,8 +116,10 @@ func main() {
 	go func() {
 		sig := <-c
 		log.Printf("Received stop signal %v. Stopping.", sig)
+
+		// Stop everything gracefully on stop signal
 		s.Stop()
-		interceptor.Stop()
+		stopInterceptors()
 	}()
 
 	wg.Wait()

--- a/sample.env
+++ b/sample.env
@@ -3,12 +3,6 @@ LISTEN_ADDRESS=<HOSTNAME:PORT>
 ### a certificate from Let's Encrypt
 #CERTMAGIC_DOMAIN=<DOMAIN>
 
-NODE_NAME=<NODE_NAME>
-NODE_PUBKEY=<PUBKEY>
-NODE_HOST=<HOSTNAME:PORT>
-
-TOKEN=<TOKEN>
-LSPD_PRIVATE_KEY=<LSPD PRIVATE KEY>
 DATABASE_URL=<DATABASE_URL>
 
 AWS_REGION=<aws region>
@@ -23,14 +17,4 @@ CHANNELMISMATCH_NOTIFICATION_TO='["Name1 <user1@domain.com>"]'
 CHANNELMISMATCH_NOTIFICATION_CC='["Name2 <user2@domain.com>","Name3 <user3@domain.com>"]'
 CHANNELMISMATCH_NOTIFICATION_FROM="Name4 <user4@domain.com>"
 
-# LND specific environment variables
-LND_ADDRESS=<HOSTNAME:PORT>
-LND_CERT=<LND_CERT> #replace each eol by \\n
-LND_MACAROON_HEX=<hex encoded macaroon>
-RUN_LND=true
-
-# CLN specific environment variables
-CLN_PLUGIN_ADDRESS=<address the lsp cln plugin listens on (ip:port)>
-CLN_SOCKET_DIR=<path to drectory cln lightning-rpc socket lives in>
-CLN_SOCKET_NAME=<name of the cln lightning-rpc file>
-RUN_CLN=true
+NODES='[ { "lspdPrivateKey": "<LSPD PRIVATE KEY>", "token": "<ACCESS TOKEN>", "host": "<HOSTNAME:PORT for lightning clients>", "publicChannelAmount": "1000183", "channelAmount": "100000", "channelPrivate": false, "targetConf": "6", "minHtlcMsat": "600", "baseFeeMsat": "1000", "feeRate": "0.000001", "timeLockDelta": "144", "channelFeePermyriad": "40", "channelMinimumFeeMsat": "2000000", "additionalChannelCapacity": "100000", "maxInactiveDuration": "3888000", "lnd": { "address": "<HOSTNAME:PORT>", "cert": "<LND_CERT base64>", "macaroon": "<LND_MACAROON hex>" } }, { "lspdPrivateKey": "<LSPD PRIVATE KEY>", "token": "<ACCESS TOKEN>", "host": "<HOSTNAME:PORT for lightning clients>", "publicChannelAmount": "1000183", "channelAmount": "100000", "channelPrivate": false, "targetConf": "6", "minHtlcMsat": "600", "baseFeeMsat": "1000", "feeRate": "0.000001", "timeLockDelta": "144", "channelFeePermyriad": "40", "channelMinimumFeeMsat": "2000000", "additionalChannelCapacity": "100000", "maxInactiveDuration": "3888000", "cln": { "pluginAddress": "<address the lsp cln plugin listens on (ip:port)>", "socketPath": "<path to the cln lightning-rpc socket file>" } } ]'


### PR DESCRIPTION
Allow lspd to 'host' multiple nodes.

- Every lightning node is its own 'lsp', so every node has a unique lsp key and a (important) corresponding `token`. In theory the lsp key could be the same on multiple nodes, but the token definitely has to differ (there's a check for that in the code as well, you can't launch lspd if you have multiple nodes configured with the same `token`.
- When calls are made over the grpc api (register payment / channel information), the 'right' node is selected based on the `token`. So LND Breez clients should end up using the LND node lsp's `token` in order to register the payment on the 'right' node.
- The .env config has changed to allow multiple nodes (you could add multiple LND/CLN nodes as well if you want)
