### PR TITLE
Stop receive first

### DIFF
--- a/itest/intercept_zero_conf_test.go
+++ b/itest/intercept_zero_conf_test.go
@@ -59,7 +59,7 @@ func testOpenZeroConfChannelOnReceive(p *testParams) {
 
 	// Make sure capacity is correct
 	chans := p.BreezClient().Node().GetChannels()
-	assert.Len(p.t, chans, 1)
+	assert.Equal(p.t, 1, len(chans))
 	c := chans[0]
 	AssertChannelCapacity(p.t, outerAmountMsat, c.CapacityMsat)
 }
@@ -114,7 +114,7 @@ func testOpenZeroConfSingleHtlc(p *testParams) {
 
 	// Make sure capacity is correct
 	chans := p.BreezClient().Node().GetChannels()
-	assert.Len(p.t, chans, 1)
+	assert.Equal(p.t, 1, len(chans))
 	c := chans[0]
 	AssertChannelCapacity(p.t, outerAmountMsat, c.CapacityMsat)
 }

--- a/itest/zero_reserve_test.go
+++ b/itest/zero_reserve_test.go
@@ -54,7 +54,7 @@ func testZeroReserve(p *testParams) {
 
 	// Make sure balance is correct
 	chans := p.BreezClient().Node().GetChannels()
-	assert.Len(p.t, chans, 1)
+	assert.Equal(p.t, 1, len(chans))
 
 	c := chans[0]
 	assert.Equal(p.t, c.RemoteReserveMsat, c.CapacityMsat/100)

--- a/main.go
+++ b/main.go
@@ -112,7 +112,7 @@ func main() {
 	}()
 
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
+	signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		sig := <-c
 		log.Printf("Received stop signal %v. Stopping.", sig)


### PR DESCRIPTION
- make sure sends complete before exiting, but receives are stopped. This to avoid having unhandled htlcs on exit. Fixes https://github.com/breez/lspd/issues/48
- Smaller subset of stopsignals to handle.
- Some test improvements.