### PR TITLE
handle clean shutdown

### DIFF
--- a/cln_plugin/cln_plugin.go
+++ b/cln_plugin/cln_plugin.go
@@ -66,6 +66,10 @@ func (c *ClnPlugin) Start() {
 	c.setupLogging()
 	go c.listenRequests()
 	<-c.done
+	s := c.server
+	if s != nil {
+		<-s.completed
+	}
 }
 
 // Stops the cln plugin. Drops any remaining work immediately.

--- a/cln_plugin/cmd/main.go
+++ b/cln_plugin/cmd/main.go
@@ -2,11 +2,20 @@ package main
 
 import (
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/breez/lspd/cln_plugin"
 )
 
 func main() {
 	plugin := cln_plugin.NewClnPlugin(os.Stdin, os.Stdout)
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-c
+		// Stop everything gracefully on stop signal
+		plugin.Stop()
+	}()
 	plugin.Start()
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/aws/aws-sdk-go v1.30.20
-	github.com/breez/lntest v0.0.17
+	github.com/breez/lntest v0.0.18
 	github.com/btcsuite/btcd v0.23.3
 	github.com/btcsuite/btcd/btcec/v2 v2.2.1
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1

--- a/itest/cln_lspd_node.go
+++ b/itest/cln_lspd_node.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sync"
+	"syscall"
 
 	"github.com/breez/lntest"
 	lspd "github.com/breez/lspd/rpc"
@@ -109,6 +110,7 @@ func (c *ClnLspNode) Start() {
 	})
 
 	cmd := exec.CommandContext(c.harness.Ctx, c.lspBase.scriptFilePath)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	logFile, err := os.Create(c.logFilePath)
 	if err != nil {
 		lntest.PerformCleanup(cleanups)
@@ -136,7 +138,7 @@ func (c *ClnLspNode) Start() {
 				return nil
 			}
 
-			proc.Kill()
+			syscall.Kill(-proc.Pid, syscall.SIGINT)
 
 			log.Printf("About to wait for lspd to exit")
 			status, err := proc.Wait()

--- a/itest/lnd_lspd_node.go
+++ b/itest/lnd_lspd_node.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 
 	"github.com/breez/lntest"
 	lspd "github.com/breez/lspd/rpc"
@@ -132,6 +133,7 @@ func (c *LndLspNode) Start() {
 	}
 
 	cmd := exec.CommandContext(c.harness.Ctx, c.lspBase.scriptFilePath)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	logFile, err := os.Create(c.logFilePath)
 	if err != nil {
 		lntest.PerformCleanup(cleanups)
@@ -159,7 +161,7 @@ func (c *LndLspNode) Start() {
 				return nil
 			}
 
-			proc.Kill()
+			syscall.Kill(-proc.Pid, syscall.SIGINT)
 
 			log.Printf("About to wait for lspd to exit")
 			status, err := proc.Wait()


### PR DESCRIPTION
- Make the CLN plugin intercept stop signals SIGINT and SIGTERM.
- Make the integration tests run commands in a process group, so child processes receive stop signals. 

Fixes https://github.com/breez/lspd/issues/45
Also fixes a problem in https://github.com/breez/lspd/pull/55 where the CLN plugin could not restart after having been shut down once.