### PR TITLE
unconfirmed utxo from internal wallet

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/aws/aws-sdk-go v1.34.0
-	github.com/breez/lntest v0.0.19
+	github.com/breez/lntest v0.0.20
 	github.com/btcsuite/btcd v0.23.3
 	github.com/btcsuite/btcd/btcec/v2 v2.2.1
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1

--- a/itest/lspd_node.go
+++ b/itest/lspd_node.go
@@ -120,7 +120,7 @@ func newLspd(h *lntest.TestHarness, name string, nodeConfig *config.NodeConfig, 
 		}
 	}
 
-	log.Printf("%+v", conf)
+	log.Printf("%s: node config: %+v", name, conf)
 	confJson, _ := json.Marshal(conf)
 	nodes := fmt.Sprintf(`NODES='[%s]'`, string(confJson))
 	env := []string{

--- a/itest/zero_conf_utxo_test.go
+++ b/itest/zero_conf_utxo_test.go
@@ -25,10 +25,14 @@ func testOpenZeroConfUtxo(p *testParams) {
 	})
 	channelId := alice.WaitForChannelReady(channel)
 
-	// Send an unconfirmed utxo to the lsp
+	tempaddr := lsp.LightningNode().GetNewAddress()
+	p.m.SendToAddress(tempaddr, 210000)
+	p.m.MineBlocks(6)
+	lsp.LightningNode().WaitForSync()
+
 	initialHeight := p.m.GetBlockHeight()
 	addr := lsp.LightningNode().GetNewAddress()
-	p.m.SendToAddress(addr, 200000)
+	lsp.LightningNode().SendToAddress(addr, 200000)
 
 	log.Printf("Adding bob's invoices")
 	outerAmountMsat := uint64(2100000)


### PR DESCRIPTION
CLN does not look at the mempool, so the integration test that tests whether channels can be opened using unconfirmed utxos didn't work for CLN.

I've changed the test so that the unconfirmed output is sent from the internal wallet instead of the miner. This way CLN does track the unconfirmed output and is able to use it for opening channels when minConfs=0.

This means using minConfs=0 does also work for CLN, but only when there are unconfirmed utxos available that are tracked by the internal wallet.

Completes https://github.com/breez/lspd/pull/68