### PR TITLE
Notifications lnd lookups

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ go 1.19
 require (
 	github.com/aws/aws-sdk-go v1.34.0
 	github.com/breez/lntest v0.0.20
-	github.com/btcsuite/btcd v0.23.3
-	github.com/btcsuite/btcd/btcec/v2 v2.2.1
-	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1
+	github.com/btcsuite/btcd v0.23.5-0.20230228185050-38331963bddd
+	github.com/btcsuite/btcd/btcec/v2 v2.3.2
+	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.2
 	github.com/caddyserver/certmagic v0.11.2
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1
 	github.com/docker/docker v20.10.24+incompatible
@@ -16,13 +16,13 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/jackc/pgtype v1.8.1
 	github.com/jackc/pgx/v4 v4.13.0
-	github.com/lightningnetwork/lightning-onion v1.2.0
-	github.com/lightningnetwork/lnd v0.15.4-beta
-	github.com/lightningnetwork/lnd/tlv v1.0.3
+	github.com/lightningnetwork/lightning-onion v1.2.1-0.20221202012345-ca23184850a1
+	github.com/lightningnetwork/lnd v0.16.2-beta
+	github.com/lightningnetwork/lnd/tlv v1.1.0
 	github.com/niftynei/glightning v0.8.2
 	github.com/stretchr/testify v1.8.1
-	golang.org/x/exp v0.0.0-20221212164502-fae10dda9338
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+	golang.org/x/exp v0.0.0-20230321023759-10a507213a29
+	golang.org/x/sync v0.1.0
 	google.golang.org/grpc v1.50.1
 )
 
@@ -32,14 +32,34 @@ require (
 	github.com/docker/distribution v2.8.1+incompatible // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/ethereum/go-ethereum v1.10.17 // indirect
+	github.com/golang-jwt/jwt/v4 v4.4.2 // indirect
+	github.com/google/uuid v1.3.0 // indirect
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
+	github.com/lightninglabs/neutrino/cache v1.1.1 // indirect
+	github.com/mattn/go-isatty v0.0.16 // indirect
 	github.com/moby/term v0.0.0-20221120202655-abb19827d345 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
 	gitlab.com/yawning/bsaes.git v0.0.0-20190805113838-0a714cd429ec // indirect
-	golang.org/x/net v0.7.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.0.1 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.0.1 // indirect
+	golang.org/x/mod v0.8.0 // indirect
+	golang.org/x/net v0.8.0 // indirect
+	golang.org/x/tools v0.6.0 // indirect
 	gotest.tools/v3 v3.4.0 // indirect
+	lukechampine.com/uint128 v1.2.0 // indirect
+	modernc.org/cc/v3 v3.40.0 // indirect
+	modernc.org/ccgo/v3 v3.16.13 // indirect
+	modernc.org/libc v1.22.2 // indirect
+	modernc.org/mathutil v1.5.0 // indirect
+	modernc.org/memory v1.4.0 // indirect
+	modernc.org/opt v0.1.3 // indirect
+	modernc.org/sqlite v1.20.3 // indirect
+	modernc.org/strutil v1.1.3 // indirect
+	modernc.org/token v1.0.1 // indirect
 )
 
 require (
@@ -47,10 +67,10 @@ require (
 	github.com/aead/siphash v1.0.1 // indirect
 	github.com/andybalholm/brotli v1.0.3 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/btcsuite/btcd/btcutil v1.1.2 // indirect
-	github.com/btcsuite/btcd/btcutil/psbt v1.1.5 // indirect
+	github.com/btcsuite/btcd/btcutil v1.1.3 // indirect
+	github.com/btcsuite/btcd/btcutil/psbt v1.1.8 // indirect
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f // indirect
-	github.com/btcsuite/btcwallet v0.16.1 // indirect
+	github.com/btcsuite/btcwallet v0.16.9 // indirect
 	github.com/btcsuite/btcwallet/wallet/txauthor v1.3.2 // indirect
 	github.com/btcsuite/btcwallet/wallet/txrules v1.2.0 // indirect
 	github.com/btcsuite/btcwallet/wallet/txsizes v1.2.3 // indirect
@@ -59,7 +79,7 @@ require (
 	github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd // indirect
 	github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792 // indirect
 	github.com/btcsuite/winsvc v1.0.0 // indirect
-	github.com/cenkalti/backoff/v4 v4.0.0 // indirect
+	github.com/cenkalti/backoff/v4 v4.1.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
@@ -68,10 +88,8 @@ require (
 	github.com/decred/dcrd/lru v1.0.0 // indirect
 	github.com/dsnet/compress v0.0.1 // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
-	github.com/dvyukov/go-fuzz v0.0.0-20210602112143-b1f3d6f4ef4e // indirect
 	github.com/ecies/go/v2 v2.0.4
 	github.com/fergusstrange/embedded-postgres v1.10.0 // indirect
-	github.com/form3tech-oss/jwt-go v3.2.3+incompatible // indirect
 	github.com/go-acme/lego/v3 v3.7.0 // indirect
 	github.com/go-errors/errors v1.0.1 // indirect
 	github.com/gofrs/uuid v4.2.0+incompatible // indirect
@@ -105,13 +123,13 @@ require (
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/lib/pq v1.10.3 // indirect
 	github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf // indirect
-	github.com/lightninglabs/neutrino v0.14.2 // indirect
+	github.com/lightninglabs/neutrino v0.15.0 // indirect
 	github.com/lightningnetwork/lnd/clock v1.1.0 // indirect
 	github.com/lightningnetwork/lnd/healthcheck v1.2.2 // indirect
-	github.com/lightningnetwork/lnd/kvdb v1.3.1 // indirect
+	github.com/lightningnetwork/lnd/kvdb v1.4.1 // indirect
 	github.com/lightningnetwork/lnd/queue v1.1.0 // indirect
 	github.com/lightningnetwork/lnd/ticker v1.1.0 // indirect
-	github.com/lightningnetwork/lnd/tor v1.0.1 // indirect
+	github.com/lightningnetwork/lnd/tor v1.1.0 // indirect
 	github.com/ltcsuite/ltcd v0.0.0-20190101042124-f37f8bf35796 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/mholt/archiver/v3 v3.5.0 // indirect
@@ -137,30 +155,25 @@ require (
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect
 	go.etcd.io/bbolt v1.3.6 // indirect
-	go.etcd.io/etcd/api/v3 v3.5.0 // indirect
-	go.etcd.io/etcd/client/pkg/v3 v3.5.0 // indirect
-	go.etcd.io/etcd/client/v2 v2.305.0 // indirect
-	go.etcd.io/etcd/client/v3 v3.5.0 // indirect
-	go.etcd.io/etcd/pkg/v3 v3.5.0 // indirect
-	go.etcd.io/etcd/raft/v3 v3.5.0 // indirect
-	go.etcd.io/etcd/server/v3 v3.5.0 // indirect
-	go.opentelemetry.io/contrib v0.20.0 // indirect
-	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.20.0 // indirect
-	go.opentelemetry.io/otel v0.20.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp v0.20.0 // indirect
-	go.opentelemetry.io/otel/metric v0.20.0 // indirect
-	go.opentelemetry.io/otel/sdk v0.20.0 // indirect
-	go.opentelemetry.io/otel/sdk/export/metric v0.20.0 // indirect
-	go.opentelemetry.io/otel/sdk/metric v0.20.0 // indirect
-	go.opentelemetry.io/otel/trace v0.20.0 // indirect
-	go.opentelemetry.io/proto/otlp v0.7.0 // indirect
+	go.etcd.io/etcd/api/v3 v3.5.7 // indirect
+	go.etcd.io/etcd/client/pkg/v3 v3.5.7 // indirect
+	go.etcd.io/etcd/client/v2 v2.305.7 // indirect
+	go.etcd.io/etcd/client/v3 v3.5.7 // indirect
+	go.etcd.io/etcd/pkg/v3 v3.5.7 // indirect
+	go.etcd.io/etcd/raft/v3 v3.5.7 // indirect
+	go.etcd.io/etcd/server/v3 v3.5.7 // indirect
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.25.0 // indirect
+	go.opentelemetry.io/otel v1.0.1 // indirect
+	go.opentelemetry.io/otel/sdk v1.0.1 // indirect
+	go.opentelemetry.io/otel/trace v1.0.1 // indirect
+	go.opentelemetry.io/proto/otlp v0.9.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.17.0 // indirect
-	golang.org/x/crypto v0.1.0 // indirect
-	golang.org/x/sys v0.5.0 // indirect
-	golang.org/x/term v0.5.0 // indirect
-	golang.org/x/text v0.7.0 // indirect
+	golang.org/x/crypto v0.7.0 // indirect
+	golang.org/x/sys v0.6.0 // indirect
+	golang.org/x/term v0.6.0 // indirect
+	golang.org/x/text v0.8.0 // indirect
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba // indirect
 	google.golang.org/genproto v0.0.0-20210617175327-b9e0b3197ced // indirect
 	google.golang.org/protobuf v1.27.1
@@ -174,6 +187,6 @@ require (
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
-replace github.com/lightningnetwork/lnd v0.15.4-beta => github.com/breez/lnd v0.15.0-beta.rc6.0.20220831104847-00b86a81e57a
+replace github.com/lightningnetwork/lnd v0.16.2-beta => github.com/breez/lnd v0.15.0-beta.rc6.0.20230501134702-cebcdf1b17fd
 
 replace github.com/niftynei/glightning v0.8.2 => github.com/breez/glightning v0.0.0-20221219103549-0e2a13b9b3ed

--- a/itest/lspd_test.go
+++ b/itest/lspd_test.go
@@ -149,4 +149,8 @@ var allTestCases = []*testCase{
 		name: "testOfflineNotificationRegularForward",
 		test: testOfflineNotificationRegularForward,
 	},
+	{
+		name: "testOfflineNotificationZeroConfChannel",
+		test: testOfflineNotificationZeroConfChannel,
+	},
 }

--- a/itest/notification_test.go
+++ b/itest/notification_test.go
@@ -181,3 +181,109 @@ func testOfflineNotificationRegularForward(p *testParams) {
 	assert.Equal(p.t, payResp.PaymentPreimage, invoiceResult.PaymentPreimage)
 	assert.Equal(p.t, amountMsat, invoiceResult.AmountReceivedMsat)
 }
+
+func testOfflineNotificationZeroConfChannel(p *testParams) {
+	alice := lntest.NewClnNode(p.h, p.m, "Alice")
+	alice.Start()
+	alice.Fund(10000000)
+	p.lsp.LightningNode().Fund(10000000)
+
+	log.Print("Opening channel between Alice and the lsp")
+	channel := alice.OpenChannel(p.lsp.LightningNode(), &lntest.OpenChannelOptions{
+		AmountSat: publicChanAmount,
+		IsPublic:  true,
+	})
+	channelId := alice.WaitForChannelReady(channel)
+
+	log.Printf("Adding bob's invoices")
+	outerAmountMsat := uint64(2100000)
+	innerAmountMsat, lspAmountMsat := calculateInnerAmountMsat(p.lsp, outerAmountMsat)
+	description := "Please pay me"
+	innerInvoice, outerInvoice := GenerateInvoices(p.BreezClient(),
+		generateInvoicesRequest{
+			innerAmountMsat: innerAmountMsat,
+			outerAmountMsat: outerAmountMsat,
+			description:     description,
+			lsp:             p.lsp,
+		})
+
+	log.Print("Connecting bob to lspd")
+	p.BreezClient().Node().ConnectPeer(p.lsp.LightningNode())
+
+	// TODO: Fix race waiting for htlc interceptor.
+	log.Printf("Waiting %v to allow htlc interceptor to activate.", htlcInterceptorDelay)
+	<-time.After(htlcInterceptorDelay)
+
+	log.Printf("Registering payment with lsp")
+	RegisterPayment(p.lsp, &lspd.PaymentInformation{
+		PaymentHash:        innerInvoice.paymentHash,
+		PaymentSecret:      innerInvoice.paymentSecret,
+		Destination:        p.BreezClient().Node().NodeId(),
+		IncomingAmountMsat: int64(outerAmountMsat),
+		OutgoingAmountMsat: int64(lspAmountMsat),
+	})
+
+	expectedheight := p.Miner().GetBlockHeight()
+	log.Printf("Alice paying")
+	route := constructRoute(p.lsp.LightningNode(), p.BreezClient().Node(), channelId, lntest.NewShortChanIDFromString("1x0x0"), outerAmountMsat)
+	_, err := alice.PayViaRoute(outerAmountMsat, outerInvoice.paymentHash, outerInvoice.paymentSecret, route)
+	assert.Nil(p.t, err)
+
+	<-time.After(time.Second * 2)
+	log.Printf("Adding bob's invoice for zero conf payment")
+	amountMsat := uint64(2100000)
+	bobInvoice := p.BreezClient().Node().CreateBolt11Invoice(&lntest.CreateInvoiceOptions{
+		AmountMsat:      amountMsat,
+		IncludeHopHints: true,
+	})
+	log.Printf(bobInvoice.Bolt11)
+
+	// Kill the mobile client
+	log.Printf("Stopping breez client")
+	p.BreezClient().Stop()
+
+	port, err := lntest.GetPort()
+	if err != nil {
+		assert.FailNow(p.t, "failed to get port for deliveeery service")
+	}
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	delivered := make(chan struct{})
+
+	notify := newNotificationDeliveryService(addr, func(resp http.ResponseWriter, req *http.Request) {
+		var body PaymentReceivedPayload
+		err = json.NewDecoder(req.Body).Decode(&body)
+		assert.NoError(p.t, err)
+
+		close(delivered)
+	})
+	go notify.Start(p.h.Ctx)
+	go func() {
+		<-delivered
+		log.Printf("Starting breez client again")
+		p.BreezClient().Start()
+		p.BreezClient().Node().ConnectPeer(p.lsp.LightningNode())
+	}()
+
+	// TODO: Fix race waiting for
+	url := "http://" + addr + "/api/v1/notify"
+	first := sha256.Sum256([]byte(url))
+	second := sha256.Sum256(first[:])
+	sig, err := ecdsa.SignCompact(p.BreezClient().Node().PrivateKey(), second[:], true)
+	assert.NoError(p.t, err)
+
+	p.lsp.NotificationsRpc().SubscribeNotifications(p.h.Ctx, &notifications.SubscribeNotificationsRequest{
+		Url:       url,
+		Signature: sig,
+	})
+
+	log.Printf("Alice paying zero conf invoice")
+	payResp := alice.Pay(bobInvoice.Bolt11)
+	invoiceResult := p.BreezClient().Node().GetInvoice(bobInvoice.PaymentHash)
+
+	assert.Equal(p.t, payResp.PaymentPreimage, invoiceResult.PaymentPreimage)
+	assert.Equal(p.t, amountMsat, invoiceResult.AmountReceivedMsat)
+
+	// Make sure we haven't accidentally mined blocks in between.
+	actualheight := p.Miner().GetBlockHeight()
+	assert.Equal(p.t, expectedheight, actualheight)
+}

--- a/main.go
+++ b/main.go
@@ -90,6 +90,7 @@ func main() {
 				log.Fatalf("failed to initialize LND client: %v", err)
 			}
 
+			client.StartListeners()
 			fwsync := lnd.NewForwardingHistorySync(client, interceptStore, forwardingStore)
 			interceptor := interceptor.NewInterceptor(client, node, interceptStore, feeEstimator, feeStrategy, notificationService)
 			htlcInterceptor, err = lnd.NewLndHtlcInterceptor(node, client, fwsync, interceptor)


### PR DESCRIPTION
This PR adds more efficient lookups in the notifications flow for LND for
- whether the peer is connected
- waiting for the peer to come online
- waiting for a channel to become active

The LND client has a listener that listens to peer events and channel events in the background. By default it does nothing and just drops the messages. When the interceptor has to wait for the peer to come online or a channel to become active, it will ask the LND client. The LND client will then signal when a peer online event or channel active event was received, so the interceptor can immediately continue.

This PR depends on the upgrade to LND 0.16.2 and also on this PR that adds the lookups to LND https://github.com/breez/lnd/pull/7

