### PR TITLE
update tests to work with cln v23.05

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/aws/aws-sdk-go v1.34.0
-	github.com/breez/lntest v0.0.20
+	github.com/breez/lntest v0.0.21
 	github.com/btcsuite/btcd v0.23.3
 	github.com/btcsuite/btcd/btcec/v2 v2.2.1
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1

--- a/itest/cln_lspd_node.go
+++ b/itest/cln_lspd_node.go
@@ -59,6 +59,7 @@ func NewClnLspdNode(h *lntest.TestHarness, m *lntest.Miner, mem *mempoolApi, nam
 		fmt.Sprintf("--cltv-delta=%d", lspCltvDelta),
 		"--max-concurrent-htlcs=30",
 		"--dev-allowdustreserve=true",
+		"--allow-deprecated-apis=true",
 	}
 	lightningNode := lntest.NewClnNode(h, m, name, args...)
 	cln := &config.ClnConfig{


### PR DESCRIPTION
The ListPeers interface has changed/will change, it no longer includes the channels starting from cln version v23.11. The integration tests were running with `--allow-deprecated-apis=false`, which made the flows fail. 

Temporarily set `--allow-deprecated-apis=true` to make sure the channel open flow still works with cln v23.05. 

A next step is changing to ListPeerChannels instead of ListPeers.