### PR TITLE
use correct version of glightning [issue #90] 

### DIFF
--- a/cln/cln_client.go
+++ b/cln/cln_client.go
@@ -12,7 +12,7 @@ import (
 	"github.com/breez/lspd/lightning"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/niftynei/glightning/glightning"
+	"github.com/elementsproject/glightning/glightning"
 	"golang.org/x/exp/slices"
 )
 
@@ -122,7 +122,7 @@ func (c *ClnClient) OpenChannel(req *lightning.OpenChannelRequest) (*wire.OutPoi
 		minConfs,
 		glightning.NewMsat(0),
 		minDepth,
-		glightning.NewSat(0),
+		glightning.NewMsat(0),
 	)
 
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/aws/aws-sdk-go v1.34.0
-	github.com/breez/lntest v0.0.23
+	github.com/breez/lntest v0.0.25
 	github.com/btcsuite/btcd v0.23.5-0.20230228185050-38331963bddd
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.2
@@ -12,6 +12,7 @@ require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1
 	github.com/docker/docker v20.10.24+incompatible
 	github.com/docker/go-connections v0.4.0
+	github.com/elementsproject/glightning v0.0.0-20230525134205-ef34d849f564
 	github.com/golang/protobuf v1.5.2
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/jackc/pgtype v1.8.1
@@ -19,7 +20,6 @@ require (
 	github.com/lightningnetwork/lightning-onion v1.2.1-0.20221202012345-ca23184850a1
 	github.com/lightningnetwork/lnd v0.16.2-beta
 	github.com/lightningnetwork/lnd/tlv v1.1.0
-	github.com/niftynei/glightning v0.8.2
 	github.com/stretchr/testify v1.8.1
 	go.starlark.net v0.0.0-20230612165344-9532f5667272
 	golang.org/x/exp v0.0.0-20230321023759-10a507213a29
@@ -189,5 +189,4 @@ require (
 )
 
 replace github.com/lightningnetwork/lnd v0.16.2-beta => github.com/breez/lnd v0.15.0-beta.rc6.0.20230501134702-cebcdf1b17fd
-
-replace github.com/niftynei/glightning v0.8.2 => github.com/breez/glightning v0.0.0-20221219103549-0e2a13b9b3ed
+replace github.com/elementsproject/glightning => github.com/breez/glightning v0.0.1-breez


### PR DESCRIPTION
- This is a "share early and often" PR
- It includes the automated tests, the change to the channel acceptor etc. these commits will get dropped for the final PR
- Fixups to this PR will run TestLspd/CLN-lspd:_testOpenZeroConfSingleHtlc
- One approach to not include the actions like this is to store them in breez/lntest under an 'actions' directory and pull them in.
- Currently the main issue seems to be when the LSP opens a zero conf channel, it's in awaiting lockin state, rather than normald (please advise)
- currently go.mod uses lnd3v/lntest but will switch to breez/lntest once that PR is merged in

https://github.com/lnd3v/lspd/actions/runs/5538109074/jobs/10107704740