### PR TITLE
remove duplicates from fee menu

### DIFF
--- a/channel_opener_server.go
+++ b/channel_opener_server.go
@@ -105,6 +105,10 @@ func (s *channelOpenerServer) createOpeningParamsMenu(
 	}
 
 	sort.Slice(menu, func(i, j int) bool {
+		if menu[i].MinMsat == menu[j].MinMsat {
+			return menu[i].Proportional < menu[j].Proportional
+		}
+
 		return menu[i].MinMsat < menu[j].MinMsat
 	})
 	return menu, nil


### PR DESCRIPTION
If multiple fee params have the same min fee and proportional fee, the resulting fee menu is invalid. Add some code to filter out duplicates.