### PR TITLE
lsps2: framework for scid management

### DIFF
--- a/lightning/client.go
+++ b/lightning/client.go
@@ -1,6 +1,7 @@
 package lightning
 
 import (
+	"context"
 	"time"
 
 	"github.com/breez/lspd/basetypes"
@@ -38,4 +39,5 @@ type Client interface {
 	GetClosedChannels(nodeID string, channelPoints map[string]uint64) (map[string]uint64, error)
 	WaitOnline(peerID []byte, deadline time.Time) error
 	WaitChannelActive(peerID []byte, deadline time.Time) error
+	WatchScids(ctx context.Context, cache ScidCacheWriter) error
 }

--- a/lightning/scid_cache.go
+++ b/lightning/scid_cache.go
@@ -1,0 +1,72 @@
+package lightning
+
+import (
+	"sync"
+
+	"github.com/breez/lspd/basetypes"
+)
+
+type ScidCacheReader interface {
+	ContainsScid(scid basetypes.ShortChannelID) bool
+}
+
+type ScidCacheWriter interface {
+	AddScids(scids ...basetypes.ShortChannelID)
+	RemoveScids(scids ...basetypes.ShortChannelID)
+	ReplaceScids(scids []basetypes.ShortChannelID)
+}
+
+type ScidCache struct {
+	activeScids map[uint64]bool
+	mtx         sync.RWMutex
+}
+
+func NewScidCache() *ScidCache {
+	return &ScidCache{
+		activeScids: make(map[uint64]bool),
+	}
+}
+
+func (s *ScidCache) ContainsScid(
+	scid basetypes.ShortChannelID,
+) bool {
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+
+	_, ok := s.activeScids[uint64(scid)]
+	return ok
+}
+
+func (s *ScidCache) AddScids(
+	scids ...basetypes.ShortChannelID,
+) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	for _, scid := range scids {
+		s.activeScids[uint64(scid)] = true
+	}
+}
+
+func (s *ScidCache) RemoveScids(
+	scids ...basetypes.ShortChannelID,
+) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	for _, scid := range scids {
+		delete(s.activeScids, uint64(scid))
+	}
+}
+
+func (s *ScidCache) ReplaceScids(
+	scids []basetypes.ShortChannelID,
+) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	s.activeScids = make(map[uint64]bool)
+	for _, scid := range scids {
+		s.activeScids[uint64(scid)] = true
+	}
+}

--- a/lsps2/scid_cleaner.go
+++ b/lsps2/scid_cleaner.go
@@ -1,0 +1,39 @@
+package lsps2
+
+import (
+	"context"
+	"log"
+	"time"
+)
+
+type ScidCleaner struct {
+	interval time.Duration
+	store    ScidStore
+}
+
+func NewScidCleaner(
+	store ScidStore,
+	interval time.Duration,
+) *ScidCleaner {
+	return &ScidCleaner{
+		interval: interval,
+		store:    store,
+	}
+}
+
+func (s *ScidCleaner) Start(ctx context.Context) error {
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case t := <-ticker.C:
+			err := s.store.RemoveExpired(ctx, t)
+			if err != nil {
+				log.Printf("Failed to remove expired scids: %v", err)
+			}
+		}
+	}
+}

--- a/lsps2/scid_service.go
+++ b/lsps2/scid_service.go
@@ -1,0 +1,84 @@
+package lsps2
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"log"
+	"math/big"
+	"time"
+
+	"github.com/breez/lspd/basetypes"
+	"github.com/breez/lspd/lightning"
+)
+
+const maxScidAttempts = 5
+
+var two = big.NewInt(2)
+var sixtyfour = big.NewInt(64)
+var maxUint64 = two.Exp(two, sixtyfour, nil)
+
+func newScid() (*basetypes.ShortChannelID, error) {
+	s, err := rand.Int(rand.Reader, maxUint64)
+	if err != nil {
+		return nil, err
+	}
+
+	scid := basetypes.ShortChannelID(s.Uint64())
+	return &scid, nil
+}
+
+type ScidService struct {
+	lspId []byte
+	store ScidStore
+	cache lightning.ScidCacheReader
+}
+
+func NewScidService(
+	lspId []byte,
+	store ScidStore,
+	cache lightning.ScidCacheReader,
+) *ScidService {
+	return &ScidService{lspId: lspId, store: store, cache: cache}
+}
+
+func (s *ScidService) ReserveNewScid(
+	ctx context.Context,
+	expiry time.Time,
+) (*basetypes.ShortChannelID, error) {
+	for attempts := 0; attempts < maxScidAttempts; attempts++ {
+		scid, err := newScid()
+		if err != nil {
+			log.Printf("NewScid() error: %v", err)
+			continue
+		}
+
+		if s.cache.ContainsScid(*scid) {
+			log.Printf(
+				"Collision with existing channel when generating new scid %s",
+				scid.ToString(),
+			)
+			continue
+		}
+
+		err = s.store.AddScid(ctx, s.lspId, *scid, expiry)
+		if err == ErrScidExists {
+			log.Printf(
+				"Collision on inserting random new scid %s",
+				scid.ToString(),
+			)
+			continue
+		}
+
+		if err != nil {
+			return nil, fmt.Errorf("failed to insert scid reservation: %w", err)
+		}
+
+		return scid, nil
+	}
+
+	return nil, fmt.Errorf(
+		"failed to reserve scid after %v attempts",
+		maxScidAttempts,
+	)
+}

--- a/lsps2/scid_store.go
+++ b/lsps2/scid_store.go
@@ -1,0 +1,26 @@
+package lsps2
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/breez/lspd/basetypes"
+)
+
+var ErrScidExists = fmt.Errorf("scid already exists")
+
+type ScidStore interface {
+	AddScid(
+		ctx context.Context,
+		lspId []byte,
+		scid basetypes.ShortChannelID,
+		expiry time.Time,
+	) error
+	RemoveScid(
+		ctx context.Context,
+		lspId []byte,
+		scid basetypes.ShortChannelID,
+	) (bool, error)
+	RemoveExpired(ctx context.Context, before time.Time) error
+}

--- a/postgresql/migrations/000014_lsps2_scids.down.sql
+++ b/postgresql/migrations/000014_lsps2_scids.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX scid_reservations_expiry_idx;
+DROP TABLE public.scid_reservations;

--- a/postgresql/migrations/000014_lsps2_scids.up.sql
+++ b/postgresql/migrations/000014_lsps2_scids.up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE public.scid_reservations (
+	id SERIAL PRIMARY KEY,
+	lspid bytea NOT NULL,
+	scid bigint NOT NULL,
+	expiry bigint NOT NULL
+);
+
+CREATE UNIQUE INDEX scid_reservations_lspid_scid_idx ON public.scid_reservations (lspid, scid);
+CREATE INDEX scid_reservations_expiry_idx ON public.scid_reservations (expiry);

--- a/postgresql/scid_store.go
+++ b/postgresql/scid_store.go
@@ -1,0 +1,88 @@
+package postgresql
+
+import (
+	"context"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/breez/lspd/basetypes"
+	"github.com/breez/lspd/lsps2"
+	"github.com/jackc/pgx/v4/pgxpool"
+)
+
+type ScidStore struct {
+	pool *pgxpool.Pool
+}
+
+func NewScidStore(pool *pgxpool.Pool) *ScidStore {
+	return &ScidStore{
+		pool: pool,
+	}
+}
+
+func (s *ScidStore) AddScid(
+	ctx context.Context,
+	lspId []byte,
+	scid basetypes.ShortChannelID,
+	expiry time.Time,
+) error {
+	_, err := s.pool.Exec(
+		ctx,
+		`INSERT INTO public.scid_reservations (lspid, scid, expiry)
+		VALUES (?, ?, ?)`,
+		lspId,
+		int64(uint64(scid)), // store the scid as int64
+		expiry.Unix(),
+	)
+
+	if err != nil && strings.Contains(err.Error(), "already exists") {
+		return lsps2.ErrScidExists
+	}
+
+	return err
+}
+
+func (s *ScidStore) RemoveScid(
+	ctx context.Context,
+	lspId []byte,
+	scid basetypes.ShortChannelID,
+) (bool, error) {
+	res, err := s.pool.Exec(
+		ctx,
+		`DELETE FROM public.scid_reservations
+		WHERE lspid = ? AND scid = ?`,
+		lspId,
+		int64(uint64(scid)), // convert scid to int64
+	)
+
+	if err != nil {
+		return false, err
+	}
+
+	return res.RowsAffected() > 0, nil
+}
+
+func (s *ScidStore) RemoveExpired(ctx context.Context, before time.Time) error {
+	rows, err := s.pool.Exec(
+		ctx,
+		`DELETE FROM public.scid_reservations
+		 WHERE expiry < ?`,
+		before.Unix(),
+	)
+
+	if err != nil {
+		return err
+	}
+
+	rowsAffected := rows.RowsAffected()
+	if rowsAffected > 0 {
+		log.Printf(
+			"Deleted %d scids from scid_reservations that expired before %s",
+			rowsAffected,
+			before.String(),
+		)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Implement https://github.com/breez/lspd/issues/72

There's a background watcher that scans the lightning node for in-use scids. These scids are cached in memory.
There's a table containing the scids in use for the LSP.

`ScidService.ReserveNewScid` attempts to reserve an unused scid. It tries a few times, just in case it runs into a collision.

To tie this PR together into something working:
- Initialize a `lightning.ScidCache`
- Run `LightningClient.WatchScids` on either the CLN or LND client
- Initialize a `jit.ScidCleaner` and start it
- Initialize a `jit.ScidService`
- Call `ScidService.ReserveNewScid` to reserve a scid

Order of pull requests:
1) https://github.com/breez/lspd/pull/114
2) https://github.com/breez/lspd/pull/115
3) https://github.com/breez/lspd/pull/116
4) (this PR) https://github.com/breez/lspd/pull/112