### PR TITLE
lsps2: implement lsps2.get_versions

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -137,7 +137,8 @@ jobs:
       max-parallel: 6
       matrix:
         test: [
-          testLsps0GetProtocolVersions
+          testLsps0GetProtocolVersions,
+          testLsps2GetVersions
         ]
         implementation: [
           CLN

--- a/itest/lspd_test.go
+++ b/itest/lspd_test.go
@@ -167,4 +167,8 @@ var allTestCases = []*testCase{
 		name: "testLsps0GetProtocolVersions",
 		test: testLsps0GetProtocolVersions,
 	},
+	{
+		name: "testLsps2GetVersions",
+		test: testLsps2GetVersions,
+	},
 }

--- a/itest/lsps2_get_versions_test.go
+++ b/itest/lsps2_get_versions_test.go
@@ -1,0 +1,40 @@
+package itest
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"log"
+
+	"github.com/breez/lntest"
+	"github.com/breez/lspd/lsps0"
+	"github.com/stretchr/testify/assert"
+)
+
+func testLsps2GetVersions(p *testParams) {
+	p.BreezClient().Node().ConnectPeer(p.Lsp().LightningNode())
+
+	rawMsg := `{
+		"method": "lsps2.get_versions",
+		"jsonrpc": "2.0",
+		"id": "example#3cad6a54d302edba4c9ade2f7ffac098",
+		"params": {}
+	  }`
+	p.BreezClient().Node().SendCustomMessage(&lntest.CustomMsgRequest{
+		PeerId: hex.EncodeToString(p.Lsp().NodeId()),
+		Type:   lsps0.Lsps0MessageType,
+		Data:   []byte(rawMsg),
+	})
+
+	resp := p.BreezClient().ReceiveCustomMessage()
+	assert.Equal(p.t, uint32(37913), resp.Type)
+
+	content := make(map[string]json.RawMessage)
+	err := json.Unmarshal(resp.Data[:], &content)
+	lntest.CheckError(p.t, err)
+
+	log.Print(string(resp.Data))
+	result := make(map[string][]int)
+	err = json.Unmarshal(content["result"], &result)
+	lntest.CheckError(p.t, err)
+	assert.Equal(p.t, []int{1}, result["versions"])
+}

--- a/lsps2/server.go
+++ b/lsps2/server.go
@@ -1,0 +1,54 @@
+package lsps2
+
+import (
+	"context"
+
+	"github.com/breez/lspd/lsps0"
+)
+
+type GetVersionsRequest struct {
+}
+
+type GetVersionsResponse struct {
+	Versions []int32 `json:"versions"`
+}
+
+type Lsps2Server interface {
+	GetVersions(ctx context.Context, request *GetVersionsRequest) (*GetVersionsResponse, error)
+}
+type server struct{}
+
+func NewLsps2Server() Lsps2Server {
+	return &server{}
+}
+
+func (s *server) GetVersions(
+	ctx context.Context,
+	request *GetVersionsRequest,
+) (*GetVersionsResponse, error) {
+	return &GetVersionsResponse{
+		Versions: []int32{1},
+	}, nil
+}
+
+func RegisterLsps2Server(s lsps0.ServiceRegistrar, l Lsps2Server) {
+	s.RegisterService(
+		&lsps0.ServiceDesc{
+			ServiceName: "lsps2",
+			HandlerType: (*Lsps2Server)(nil),
+			Methods: []lsps0.MethodDesc{
+				{
+					MethodName: "lsps2.get_versions",
+					Handler: func(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
+						in := new(GetVersionsRequest)
+						if err := dec(in); err != nil {
+							return nil, err
+						}
+						return srv.(Lsps2Server).GetVersions(ctx, in)
+					},
+				},
+			},
+		},
+		l,
+	)
+}

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/breez/lspd/interceptor"
 	"github.com/breez/lspd/lnd"
 	"github.com/breez/lspd/lsps0"
+	"github.com/breez/lspd/lsps2"
 	"github.com/breez/lspd/mempool"
 	"github.com/breez/lspd/notifications"
 	"github.com/breez/lspd/postgresql"
@@ -116,7 +117,9 @@ func main() {
 			go msgClient.Start()
 			msgServer := lsps0.NewServer()
 			protocolServer := lsps0.NewProtocolServer([]uint32{2})
+			lsps2Server := lsps2.NewLsps2Server()
 			lsps0.RegisterProtocolServer(msgServer, protocolServer)
+			lsps2.RegisterLsps2Server(msgServer, lsps2Server)
 			msgClient.WaitStarted()
 			defer msgClient.Stop()
 			go msgServer.Serve(msgClient)


### PR DESCRIPTION
First implementation of an lsps2 server method.
https://github.com/BitcoinAndLightningLayerSpecs/lsp/tree/main/LSPS2#0-api-version

https://github.com/breez/lspd/issues/106

NOTE: points at `lsps0` branch for now, to show the diff, because it depends on https://github.com/breez/lspd/pull/114

Order of pull requests:
1) https://github.com/breez/lspd/pull/114
2) (this PR) https://github.com/breez/lspd/pull/115
3) https://github.com/breez/lspd/pull/116
4) https://github.com/breez/lspd/pull/120