### PR TITLE
Implement lsps2.get_info

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -158,3 +158,20 @@ jobs:
           CLIENT_REF: ${{ env.CLIENT_REF }}
           GO_VERSION: ${{ env.GO_VERSION }}
           CLN_VERSION: ${{ env.CLN_VERSION }}
+
+  run-unit-tests:
+    runs-on: ubuntu-22.04
+    name: Run unit tests
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Get dependencies
+        run: |
+          go get github.com/breez/lspd
+          go get github.com/breez/lspd/cln_plugin
+          go get github.com/breez/lspd/itest
+
+      - name: Test
+        run: go test -short `go list ./... | grep -v /itest`
+      

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -138,7 +138,8 @@ jobs:
       matrix:
         test: [
           testLsps0GetProtocolVersions,
-          testLsps2GetVersions
+          testLsps2GetVersions,
+          testLsps2GetInfo
         ]
         implementation: [
           CLN

--- a/channel_opener_server.go
+++ b/channel_opener_server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/breez/lspd/interceptor"
 	"github.com/breez/lspd/lightning"
 	lspdrpc "github.com/breez/lspd/rpc"
+	"github.com/breez/lspd/shared"
 	ecies "github.com/ecies/go/v2"
 	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc/codes"
@@ -54,26 +55,26 @@ func (s *channelOpenerServer) ChannelInformation(ctx context.Context, in *lspdrp
 	}
 
 	return &lspdrpc.ChannelInformationReply{
-		Name:                  node.nodeConfig.Name,
-		Pubkey:                node.nodeConfig.NodePubkey,
-		Host:                  node.nodeConfig.Host,
-		ChannelCapacity:       int64(node.nodeConfig.PublicChannelAmount),
-		TargetConf:            int32(node.nodeConfig.TargetConf),
-		MinHtlcMsat:           int64(node.nodeConfig.MinHtlcMsat),
-		BaseFeeMsat:           int64(node.nodeConfig.BaseFeeMsat),
-		FeeRate:               node.nodeConfig.FeeRate,
-		TimeLockDelta:         node.nodeConfig.TimeLockDelta,
-		ChannelFeePermyriad:   int64(node.nodeConfig.ChannelFeePermyriad),
-		ChannelMinimumFeeMsat: int64(node.nodeConfig.ChannelMinimumFeeMsat),
-		LspPubkey:             node.publicKey.SerializeCompressed(), // TODO: Is the publicKey different from the ecies public key?
-		MaxInactiveDuration:   int64(node.nodeConfig.MaxInactiveDuration),
+		Name:                  node.NodeConfig.Name,
+		Pubkey:                node.NodeConfig.NodePubkey,
+		Host:                  node.NodeConfig.Host,
+		ChannelCapacity:       int64(node.NodeConfig.PublicChannelAmount),
+		TargetConf:            int32(node.NodeConfig.TargetConf),
+		MinHtlcMsat:           int64(node.NodeConfig.MinHtlcMsat),
+		BaseFeeMsat:           int64(node.NodeConfig.BaseFeeMsat),
+		FeeRate:               node.NodeConfig.FeeRate,
+		TimeLockDelta:         node.NodeConfig.TimeLockDelta,
+		ChannelFeePermyriad:   int64(node.NodeConfig.ChannelFeePermyriad),
+		ChannelMinimumFeeMsat: int64(node.NodeConfig.ChannelMinimumFeeMsat),
+		LspPubkey:             node.PublicKey.SerializeCompressed(), // TODO: Is the publicKey different from the ecies public key?
+		MaxInactiveDuration:   int64(node.NodeConfig.MaxInactiveDuration),
 		OpeningFeeParamsMenu:  params,
 	}, nil
 }
 
 func (s *channelOpenerServer) createOpeningParamsMenu(
 	ctx context.Context,
-	node *node,
+	node *shared.Node,
 	token string,
 ) ([]*lspdrpc.OpeningFeeParams, error) {
 	var menu []*lspdrpc.OpeningFeeParams
@@ -132,13 +133,13 @@ func paramsHash(params *lspdrpc.OpeningFeeParams) ([]byte, error) {
 	return hash[:], nil
 }
 
-func createPromise(node *node, params *lspdrpc.OpeningFeeParams) (*string, error) {
+func createPromise(node *shared.Node, params *lspdrpc.OpeningFeeParams) (*string, error) {
 	hash, err := paramsHash(params)
 	if err != nil {
 		return nil, err
 	}
 	// Sign the hash with the private key of the LSP id.
-	sig, err := ecdsa.SignCompact(node.privateKey, hash[:], true)
+	sig, err := ecdsa.SignCompact(node.PrivateKey, hash[:], true)
 	if err != nil {
 		log.Printf("createPromise: SignCompact error: %v", err)
 		return nil, err
@@ -147,7 +148,7 @@ func createPromise(node *node, params *lspdrpc.OpeningFeeParams) (*string, error
 	return &promise, nil
 }
 
-func verifyPromise(node *node, params *lspdrpc.OpeningFeeParams) error {
+func verifyPromise(node *shared.Node, params *lspdrpc.OpeningFeeParams) error {
 	hash, err := paramsHash(params)
 	if err != nil {
 		return err
@@ -162,14 +163,14 @@ func verifyPromise(node *node, params *lspdrpc.OpeningFeeParams) error {
 		log.Printf("verifyPromise: RecoverCompact(%x) error: %v", sig, err)
 		return err
 	}
-	if !node.publicKey.IsEqual(pub) {
+	if !node.PublicKey.IsEqual(pub) {
 		log.Print("verifyPromise: not signed by us", err)
 		return fmt.Errorf("invalid promise")
 	}
 	return nil
 }
 
-func validateOpeningFeeParams(node *node, params *lspdrpc.OpeningFeeParams) bool {
+func validateOpeningFeeParams(node *shared.Node, params *lspdrpc.OpeningFeeParams) bool {
 	if params == nil {
 		return false
 	}
@@ -202,10 +203,10 @@ func (s *channelOpenerServer) RegisterPayment(
 		return nil, err
 	}
 
-	data, err := ecies.Decrypt(node.eciesPrivateKey, in.Blob)
+	data, err := ecies.Decrypt(node.EciesPrivateKey, in.Blob)
 	if err != nil {
 		log.Printf("ecies.Decrypt(%x) error: %v", in.Blob, err)
-		data, err = btceclegacy.Decrypt(node.privateKey, in.Blob)
+		data, err = btceclegacy.Decrypt(node.PrivateKey, in.Blob)
 		if err != nil {
 			log.Printf("btcec.Decrypt(%x) error: %v", in.Blob, err)
 			return nil, fmt.Errorf("btcec.Decrypt(%x) error: %w", in.Blob, err)
@@ -243,10 +244,10 @@ func (s *channelOpenerServer) RegisterPayment(
 	} else {
 		log.Printf("DEPRECATED: RegisterPayment with deprecated fee mechanism.")
 		pi.OpeningFeeParams = &lspdrpc.OpeningFeeParams{
-			MinMsat:              uint64(node.nodeConfig.ChannelMinimumFeeMsat),
-			Proportional:         uint32(node.nodeConfig.ChannelFeePermyriad * 100),
+			MinMsat:              uint64(node.NodeConfig.ChannelMinimumFeeMsat),
+			Proportional:         uint32(node.NodeConfig.ChannelFeePermyriad * 100),
 			ValidUntil:           time.Now().UTC().Add(time.Duration(time.Hour * 24)).Format(basetypes.TIME_FORMAT),
-			MaxIdleTime:          uint32(node.nodeConfig.MaxInactiveDuration / 600),
+			MaxIdleTime:          uint32(node.NodeConfig.MaxInactiveDuration / 600),
 			MaxClientToSelfDelay: uint32(10000),
 		}
 	}
@@ -278,25 +279,25 @@ func (s *channelOpenerServer) OpenChannel(ctx context.Context, in *lspdrpc.OpenC
 		return nil, err
 	}
 
-	r, err, _ := node.openChannelReqGroup.Do(in.Pubkey, func() (interface{}, error) {
+	r, err, _ := node.OpenChannelReqGroup.Do(in.Pubkey, func() (interface{}, error) {
 		pubkey, err := hex.DecodeString(in.Pubkey)
 		if err != nil {
 			return nil, err
 		}
 
-		channelCount, err := node.client.GetNodeChannelCount(pubkey)
+		channelCount, err := node.Client.GetNodeChannelCount(pubkey)
 		if err != nil {
 			return nil, err
 		}
 
 		var outPoint *wire.OutPoint
 		if channelCount == 0 {
-			outPoint, err = node.client.OpenChannel(&lightning.OpenChannelRequest{
-				CapacitySat: node.nodeConfig.ChannelAmount,
+			outPoint, err = node.Client.OpenChannel(&lightning.OpenChannelRequest{
+				CapacitySat: node.NodeConfig.ChannelAmount,
 				Destination: pubkey,
-				TargetConf:  &node.nodeConfig.TargetConf,
-				MinHtlcMsat: node.nodeConfig.MinHtlcMsat,
-				IsPrivate:   node.nodeConfig.ChannelPrivate,
+				TargetConf:  &node.NodeConfig.TargetConf,
+				MinHtlcMsat: node.NodeConfig.MinHtlcMsat,
+				IsPrivate:   node.NodeConfig.ChannelPrivate,
 			})
 
 			if err != nil {
@@ -316,13 +317,13 @@ func (s *channelOpenerServer) OpenChannel(ctx context.Context, in *lspdrpc.OpenC
 	return r.(*lspdrpc.OpenChannelReply), err
 }
 
-func (n *node) getSignedEncryptedData(in *lspdrpc.Encrypted) (string, []byte, bool, error) {
+func getSignedEncryptedData(n *shared.Node, in *lspdrpc.Encrypted) (string, []byte, bool, error) {
 	usedEcies := true
-	signedBlob, err := ecies.Decrypt(n.eciesPrivateKey, in.Data)
+	signedBlob, err := ecies.Decrypt(n.EciesPrivateKey, in.Data)
 	if err != nil {
 		log.Printf("ecies.Decrypt(%x) error: %v", in.Data, err)
 		usedEcies = false
-		signedBlob, err = btceclegacy.Decrypt(n.privateKey, in.Data)
+		signedBlob, err = btceclegacy.Decrypt(n.PrivateKey, in.Data)
 		if err != nil {
 			log.Printf("btcec.Decrypt(%x) error: %v", in.Data, err)
 			return "", nil, usedEcies, fmt.Errorf("btcec.Decrypt(%x) error: %w", in.Data, err)
@@ -362,7 +363,7 @@ func (s *channelOpenerServer) CheckChannels(ctx context.Context, in *lspdrpc.Enc
 		return nil, err
 	}
 
-	nodeID, data, usedEcies, err := node.getSignedEncryptedData(in)
+	nodeID, data, usedEcies, err := getSignedEncryptedData(node, in)
 	if err != nil {
 		log.Printf("getSignedEncryptedData error: %v", err)
 		return nil, fmt.Errorf("getSignedEncryptedData error: %v", err)
@@ -373,7 +374,7 @@ func (s *channelOpenerServer) CheckChannels(ctx context.Context, in *lspdrpc.Enc
 		log.Printf("proto.Unmarshal(%x) error: %v", data, err)
 		return nil, fmt.Errorf("proto.Unmarshal(%x) error: %w", data, err)
 	}
-	closedChannels, err := node.client.GetClosedChannels(nodeID, checkChannelsRequest.WaitingCloseChannels)
+	closedChannels, err := node.Client.GetClosedChannels(nodeID, checkChannelsRequest.WaitingCloseChannels)
 	if err != nil {
 		log.Printf("GetClosedChannels(%v) error: %v", checkChannelsRequest.FakeChannels, err)
 		return nil, fmt.Errorf("GetClosedChannels(%v) error: %w", checkChannelsRequest.FakeChannels, err)
@@ -395,7 +396,7 @@ func (s *channelOpenerServer) CheckChannels(ctx context.Context, in *lspdrpc.Enc
 
 	var encrypted []byte
 	if usedEcies {
-		encrypted, err = ecies.Encrypt(node.eciesPublicKey, dataReply)
+		encrypted, err = ecies.Encrypt(node.EciesPublicKey, dataReply)
 		if err != nil {
 			log.Printf("ecies.Encrypt() error: %v", err)
 			return nil, fmt.Errorf("ecies.Encrypt() error: %w", err)
@@ -411,7 +412,7 @@ func (s *channelOpenerServer) CheckChannels(ctx context.Context, in *lspdrpc.Enc
 	return &lspdrpc.Encrypted{Data: encrypted}, nil
 }
 
-func (s *channelOpenerServer) getNode(ctx context.Context) (*node, string, error) {
+func (s *channelOpenerServer) getNode(ctx context.Context) (*shared.Node, string, error) {
 	nd := ctx.Value(contextKey("node"))
 	if nd == nil {
 		return nil, "", status.Errorf(codes.PermissionDenied, "Not authorized")

--- a/cln/cln_interceptor.go
+++ b/cln/cln_interceptor.go
@@ -284,7 +284,7 @@ func encodePayloadWithNextHop(payload []byte, channelId uint64, amountToForward 
 	tlvRecords := tlv.MapToRecords(uTlvMap)
 	s, err = tlv.NewStream(tlvRecords...)
 	if err != nil {
-		return nil, fmt.Errorf("tlv.NewStream(%x) error: %v", tlvRecords, err)
+		return nil, fmt.Errorf("tlv.NewStream(%v) error: %v", tlvRecords, err)
 	}
 	var newPayloadBuf bytes.Buffer
 	err = s.Encode(&newPayloadBuf)

--- a/config/config.go
+++ b/config/config.go
@@ -70,6 +70,9 @@ type NodeConfig struct {
 	// peer is offline.
 	NotificationTimeout string `json:"notificationTimeout,string"`
 
+	MinPaymentSizeMsat uint64 `json:"minPaymentSizeMsat,string"`
+	MaxPaymentSizeMsat uint64 `json:"maxPaymentSizeMsat,string"`
+
 	// Set this field to connect to an LND node.
 	Lnd *LndConfig `json:"lnd,omitempty"`
 

--- a/itest/lspd_test.go
+++ b/itest/lspd_test.go
@@ -171,4 +171,8 @@ var allTestCases = []*testCase{
 		name: "testLsps2GetVersions",
 		test: testLsps2GetVersions,
 	},
+	{
+		name: "testLsps2GetInfo",
+		test: testLsps2GetInfo,
+	},
 }

--- a/itest/lspd_test.go
+++ b/itest/lspd_test.go
@@ -13,6 +13,10 @@ import (
 var defaultTimeout time.Duration = time.Second * 120
 
 func TestLspd(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+		return
+	}
 	testCases := allTestCases
 	runTests(t, testCases, "LND-lspd", lndLspFunc, lndClientFunc)
 	runTests(t, testCases, "CLN-lspd", clnLspFunc, clnClientFunc)

--- a/itest/lsps2_get_info_test.go
+++ b/itest/lsps2_get_info_test.go
@@ -1,0 +1,70 @@
+package itest
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"log"
+	"time"
+
+	"github.com/breez/lntest"
+	"github.com/breez/lspd/lsps0"
+	"github.com/stretchr/testify/assert"
+)
+
+func testLsps2GetInfo(p *testParams) {
+	SetFeeParams(p.Lsp(), []*FeeParamSetting{
+		{
+			Validity:     time.Second * 3600,
+			MinMsat:      3000000,
+			Proportional: 1000,
+		},
+		{
+			Validity:     time.Second * 2800,
+			MinMsat:      2000000,
+			Proportional: 800,
+		},
+	})
+	p.BreezClient().Node().ConnectPeer(p.Lsp().LightningNode())
+
+	rawMsg := `{
+		"method": "lsps2.get_info",
+		"jsonrpc": "2.0",
+		"id": "example#3cad6a54d302edba4c9ade2f7ffac098",
+		"params": {
+			"version": 1,
+			"token": "hello"
+		}
+	  }`
+	p.BreezClient().Node().SendCustomMessage(&lntest.CustomMsgRequest{
+		PeerId: hex.EncodeToString(p.Lsp().NodeId()),
+		Type:   lsps0.Lsps0MessageType,
+		Data:   []byte(rawMsg),
+	})
+
+	resp := p.BreezClient().ReceiveCustomMessage()
+	log.Print(string(resp.Data))
+	assert.Equal(p.t, uint32(37913), resp.Type)
+
+	content := make(map[string]json.RawMessage)
+	err := json.Unmarshal(resp.Data[:], &content)
+	lntest.CheckError(p.t, err)
+
+	result := make(map[string]json.RawMessage)
+	err = json.Unmarshal(content["result"], &result)
+	lntest.CheckError(p.t, err)
+
+	menu := []*struct {
+		MinFeeMsat           uint64 `json:"min_fee_msat,string"`
+		Proportional         uint32 `json:"proportional"`
+		ValidUntil           string `json:"valid_until"`
+		MinLifetime          uint32 `json:"min_lifetime"`
+		MaxClientToSelfDelay uint32 `json:"max_client_to_self_delay"`
+		Promise              string `json:"promise"`
+	}{}
+	err = json.Unmarshal(result["opening_fee_params_menu"], &menu)
+	lntest.CheckError(p.t, err)
+
+	assert.Len(p.t, menu, 2)
+	assert.Equal(p.t, uint64(2000000), menu[0].MinFeeMsat)
+	assert.Equal(p.t, uint64(3000000), menu[1].MinFeeMsat)
+}

--- a/lsps2/server.go
+++ b/lsps2/server.go
@@ -2,24 +2,63 @@ package lsps2
 
 import (
 	"context"
+	"log"
 
 	"github.com/breez/lspd/lsps0"
+	"github.com/breez/lspd/lsps0/codes"
+	"github.com/breez/lspd/lsps0/status"
+	"github.com/breez/lspd/shared"
 )
+
+var SupportedVersion uint32 = 1
 
 type GetVersionsRequest struct {
 }
 
 type GetVersionsResponse struct {
-	Versions []int32 `json:"versions"`
+	Versions []uint32 `json:"versions"`
+}
+
+type GetInfoRequest struct {
+	Version uint32  `json:"version"`
+	Token   *string `json:"token,omitempty"`
+}
+
+type GetInfoResponse struct {
+	OpeningFeeParamsMenu []*OpeningFeeParams `json:"opening_fee_params_menu"`
+	MinPaymentSizeMsat   uint64              `json:"min_payment_size_msat,string"`
+	MaxPaymentSizeMsat   uint64              `json:"max_payment_size_msat,string"`
+}
+
+type OpeningFeeParams struct {
+	MinFeeMsat           uint64 `json:"min_fee_msat,string"`
+	Proportional         uint32 `json:"proportional"`
+	ValidUntil           string `json:"valid_until"`
+	MinLifetime          uint32 `json:"min_lifetime"`
+	MaxClientToSelfDelay uint32 `json:"max_client_to_self_delay"`
+	Promise              string `json:"promise"`
 }
 
 type Lsps2Server interface {
 	GetVersions(ctx context.Context, request *GetVersionsRequest) (*GetVersionsResponse, error)
+	GetInfo(ctx context.Context, request *GetInfoRequest) (*GetInfoResponse, error)
 }
-type server struct{}
+type server struct {
+	openingService shared.OpeningService
+	nodesService   shared.NodesService
+	node           *shared.Node
+}
 
-func NewLsps2Server() Lsps2Server {
-	return &server{}
+func NewLsps2Server(
+	openingService shared.OpeningService,
+	nodesService shared.NodesService,
+	node *shared.Node,
+) Lsps2Server {
+	return &server{
+		openingService: openingService,
+		nodesService:   nodesService,
+		node:           node,
+	}
 }
 
 func (s *server) GetVersions(
@@ -27,7 +66,64 @@ func (s *server) GetVersions(
 	request *GetVersionsRequest,
 ) (*GetVersionsResponse, error) {
 	return &GetVersionsResponse{
-		Versions: []int32{1},
+		Versions: []uint32{SupportedVersion},
+	}, nil
+}
+
+func (s *server) GetInfo(
+	ctx context.Context,
+	request *GetInfoRequest,
+) (*GetInfoResponse, error) {
+	if request.Version != uint32(SupportedVersion) {
+		return nil, status.New(codes.Code(1), "unsupported_version").Err()
+	}
+
+	if request.Token == nil || *request.Token == "" {
+		return nil, status.New(codes.Code(2), "unrecognized_or_stale_token").Err()
+	}
+
+	node, err := s.nodesService.GetNode(*request.Token)
+	if err == shared.ErrNodeNotFound {
+		return nil, status.New(codes.Code(2), "unrecognized_or_stale_token").Err()
+	}
+	if err != nil {
+		log.Printf("Lsps2Server.GetInfo: nodesService.GetNode(%s) err: %v", *request.Token, err)
+		return nil, status.New(codes.InternalError, "internal error").Err()
+	}
+	if node.NodeConfig.NodePubkey != s.node.NodeConfig.NodePubkey {
+		log.Printf(
+			"Lsps2Server.GetInfo: Got token '%s' on node '%s', but was meant for node '%s'",
+			*request.Token,
+			s.node.NodeConfig.NodePubkey,
+			node.NodeConfig.NodePubkey,
+		)
+		return nil, status.New(codes.Code(2), "unrecognized_or_stale_token").Err()
+	}
+
+	m, err := s.openingService.GetFeeParamsMenu(*request.Token, node.PrivateKey)
+	if err == shared.ErrNodeNotFound {
+		return nil, status.New(codes.Code(2), "unrecognized_or_stale_token").Err()
+	}
+	if err != nil {
+		log.Printf("Lsps2Server.GetInfo: openingService.GetFeeParamsMenu(%s) err: %v", *request.Token, err)
+		return nil, status.New(codes.InternalError, "internal error").Err()
+	}
+
+	menu := []*OpeningFeeParams{}
+	for _, p := range m {
+		menu = append(menu, &OpeningFeeParams{
+			MinFeeMsat:           p.MinFeeMsat,
+			Proportional:         p.Proportional,
+			ValidUntil:           p.ValidUntil,
+			MinLifetime:          p.MinLifetime,
+			MaxClientToSelfDelay: p.MaxClientToSelfDelay,
+			Promise:              p.Promise,
+		})
+	}
+	return &GetInfoResponse{
+		OpeningFeeParamsMenu: menu,
+		MinPaymentSizeMsat:   node.NodeConfig.MinPaymentSizeMsat,
+		MaxPaymentSizeMsat:   node.NodeConfig.MaxPaymentSizeMsat,
 	}, nil
 }
 
@@ -45,6 +141,16 @@ func RegisterLsps2Server(s lsps0.ServiceRegistrar, l Lsps2Server) {
 							return nil, err
 						}
 						return srv.(Lsps2Server).GetVersions(ctx, in)
+					},
+				},
+				{
+					MethodName: "lsps2.get_info",
+					Handler: func(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
+						in := new(GetInfoRequest)
+						if err := dec(in); err != nil {
+							return nil, err
+						}
+						return srv.(Lsps2Server).GetInfo(ctx, in)
 					},
 				},
 			},

--- a/lsps2/server_test.go
+++ b/lsps2/server_test.go
@@ -1,0 +1,145 @@
+package lsps2
+
+import (
+	"context"
+	"testing"
+
+	"github.com/breez/lspd/config"
+	"github.com/breez/lspd/lsps0/status"
+	"github.com/breez/lspd/shared"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockNodesService struct {
+	node *shared.Node
+	err  error
+}
+
+func (m *mockNodesService) GetNode(token string) (*shared.Node, error) {
+	return m.node, m.err
+}
+
+func (m *mockNodesService) GetNodes() []*shared.Node {
+	return []*shared.Node{m.node}
+}
+
+type mockOpeningService struct {
+	menu  []*shared.OpeningFeeParams
+	err   error
+	valid bool
+}
+
+func (m *mockOpeningService) GetFeeParamsMenu(
+	token string,
+	privateKey *btcec.PrivateKey,
+) ([]*shared.OpeningFeeParams, error) {
+	return m.menu, m.err
+}
+
+func (m *mockOpeningService) ValidateOpeningFeeParams(
+	params *shared.OpeningFeeParams,
+	publicKey *btcec.PublicKey,
+) bool {
+	return m.valid
+}
+
+var token = "blah"
+var node = &shared.Node{
+	NodeConfig: &config.NodeConfig{
+		MinPaymentSizeMsat: 123,
+		MaxPaymentSizeMsat: 456,
+	},
+}
+
+func Test_GetInfo_UnsupportedVersion(t *testing.T) {
+	n := &mockNodesService{}
+	o := &mockOpeningService{}
+	s := NewLsps2Server(o, n, nil)
+	_, err := s.GetInfo(context.Background(), &GetInfoRequest{
+		Version: 2,
+		Token:   &token,
+	})
+
+	st := status.Convert(err)
+	assert.Equal(t, uint32(1), uint32(st.Code))
+	assert.Equal(t, "unsupported_version", st.Message)
+}
+
+func Test_GetInfo_InvalidToken(t *testing.T) {
+	n := &mockNodesService{
+		err: shared.ErrNodeNotFound,
+	}
+	o := &mockOpeningService{}
+	s := NewLsps2Server(o, n, nil)
+	_, err := s.GetInfo(context.Background(), &GetInfoRequest{
+		Version: 1,
+		Token:   &token,
+	})
+
+	st := status.Convert(err)
+	assert.Equal(t, uint32(2), uint32(st.Code))
+	assert.Equal(t, "unrecognized_or_stale_token", st.Message)
+}
+
+func Test_GetInfo_EmptyMenu(t *testing.T) {
+	n := &mockNodesService{node: node}
+	o := &mockOpeningService{menu: []*shared.OpeningFeeParams{}}
+	s := NewLsps2Server(o, n, node)
+	resp, err := s.GetInfo(context.Background(), &GetInfoRequest{
+		Version: 1,
+		Token:   &token,
+	})
+
+	assert.Nil(t, err)
+	assert.Equal(t, []*OpeningFeeParams{}, resp.OpeningFeeParamsMenu)
+	assert.Equal(t, node.NodeConfig.MinPaymentSizeMsat, resp.MinPaymentSizeMsat)
+	assert.Equal(t, node.NodeConfig.MaxPaymentSizeMsat, resp.MaxPaymentSizeMsat)
+}
+
+func Test_GetInfo_PopulatedMenu_Ordered(t *testing.T) {
+	n := &mockNodesService{node: node}
+	o := &mockOpeningService{menu: []*shared.OpeningFeeParams{
+		{
+			MinFeeMsat:           1,
+			Proportional:         2,
+			ValidUntil:           "a",
+			MinLifetime:          3,
+			MaxClientToSelfDelay: 4,
+			Promise:              "b",
+		},
+		{
+			MinFeeMsat:           5,
+			Proportional:         6,
+			ValidUntil:           "c",
+			MinLifetime:          7,
+			MaxClientToSelfDelay: 8,
+			Promise:              "d",
+		},
+	}}
+	s := NewLsps2Server(o, n, node)
+	resp, err := s.GetInfo(context.Background(), &GetInfoRequest{
+		Version: 1,
+		Token:   &token,
+	})
+
+	assert.Nil(t, err)
+	assert.Len(t, resp.OpeningFeeParamsMenu, 2)
+
+	assert.Equal(t, uint64(1), resp.OpeningFeeParamsMenu[0].MinFeeMsat)
+	assert.Equal(t, uint32(2), resp.OpeningFeeParamsMenu[0].Proportional)
+	assert.Equal(t, "a", resp.OpeningFeeParamsMenu[0].ValidUntil)
+	assert.Equal(t, uint32(3), resp.OpeningFeeParamsMenu[0].MinLifetime)
+	assert.Equal(t, uint32(4), resp.OpeningFeeParamsMenu[0].MaxClientToSelfDelay)
+	assert.Equal(t, "b", resp.OpeningFeeParamsMenu[0].Promise)
+
+	assert.Equal(t, uint64(5), resp.OpeningFeeParamsMenu[1].MinFeeMsat)
+	assert.Equal(t, uint32(6), resp.OpeningFeeParamsMenu[1].Proportional)
+	assert.Equal(t, "c", resp.OpeningFeeParamsMenu[1].ValidUntil)
+	assert.Equal(t, uint32(7), resp.OpeningFeeParamsMenu[1].MinLifetime)
+	assert.Equal(t, uint32(8), resp.OpeningFeeParamsMenu[1].MaxClientToSelfDelay)
+	assert.Equal(t, "d", resp.OpeningFeeParamsMenu[1].Promise)
+
+	assert.Equal(t, node.NodeConfig.MinPaymentSizeMsat, resp.MinPaymentSizeMsat)
+	assert.Equal(t, node.NodeConfig.MaxPaymentSizeMsat, resp.MaxPaymentSizeMsat)
+}

--- a/main.go
+++ b/main.go
@@ -89,6 +89,7 @@ func main() {
 	notificationsStore := postgresql.NewNotificationsStore(pool)
 	notificationService := notifications.NewNotificationService(notificationsStore)
 
+	openingService := shared.NewOpeningService(interceptStore, nodesService)
 	var interceptors []interceptor.HtlcInterceptor
 	nodes := nodesService.GetNodes()
 	for _, node := range nodes {
@@ -141,7 +142,7 @@ func main() {
 
 	address := os.Getenv("LISTEN_ADDRESS")
 	certMagicDomain := os.Getenv("CERTMAGIC_DOMAIN")
-	cs := NewChannelOpenerServer(interceptStore)
+	cs := NewChannelOpenerServer(interceptStore, openingService)
 	ns := notifications.NewNotificationsServer(notificationsStore)
 	s, err := NewGrpcServer(nodesService, address, certMagicDomain, cs, ns)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -125,7 +125,7 @@ func main() {
 			go msgClient.Start()
 			msgServer := lsps0.NewServer()
 			protocolServer := lsps0.NewProtocolServer([]uint32{2})
-			lsps2Server := lsps2.NewLsps2Server()
+			lsps2Server := lsps2.NewLsps2Server(openingService, nodesService, node)
 			lsps0.RegisterProtocolServer(msgServer, protocolServer)
 			lsps2.RegisterLsps2Server(msgServer, lsps2Server)
 			msgClient.WaitStarted()

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/breez/lspd/mempool"
 	"github.com/breez/lspd/notifications"
 	"github.com/breez/lspd/postgresql"
+	"github.com/breez/lspd/shared"
 	"github.com/btcsuite/btcd/btcec/v2"
 )
 
@@ -42,6 +43,11 @@ func main() {
 
 	if len(nodes) == 0 {
 		log.Fatalf("need at least one node configured in NODES.")
+	}
+
+	nodesService, err := shared.NewNodesService(nodes)
+	if err != nil {
+		log.Fatalf("failed to create nodes service: %v", err)
 	}
 
 	mempoolUrl := os.Getenv("MEMPOOL_API_BASE_URL")
@@ -136,7 +142,7 @@ func main() {
 	certMagicDomain := os.Getenv("CERTMAGIC_DOMAIN")
 	cs := NewChannelOpenerServer(interceptStore)
 	ns := notifications.NewNotificationsServer(notificationsStore)
-	s, err := NewGrpcServer(nodes, address, certMagicDomain, cs, ns)
+	s, err := NewGrpcServer(nodesService, address, certMagicDomain, cs, ns)
 	if err != nil {
 		log.Fatalf("failed to initialize grpc server: %v", err)
 	}

--- a/shared/nodes_service.go
+++ b/shared/nodes_service.go
@@ -1,0 +1,118 @@
+package shared
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+
+	"github.com/breez/lspd/cln"
+	"github.com/breez/lspd/config"
+	"github.com/breez/lspd/lightning"
+	"github.com/breez/lspd/lnd"
+	"github.com/btcsuite/btcd/btcec/v2"
+	ecies "github.com/ecies/go/v2"
+	"golang.org/x/sync/singleflight"
+)
+
+type Node struct {
+	Client              lightning.Client
+	NodeConfig          *config.NodeConfig
+	PrivateKey          *btcec.PrivateKey
+	PublicKey           *btcec.PublicKey
+	EciesPrivateKey     *ecies.PrivateKey
+	EciesPublicKey      *ecies.PublicKey
+	OpenChannelReqGroup singleflight.Group
+}
+
+type NodesService interface {
+	GetNode(token string) (*Node, error)
+}
+type nodesService struct {
+	nodes map[string]*Node
+}
+
+func NewNodesService(configs []*config.NodeConfig) (NodesService, error) {
+	if len(configs) == 0 {
+		return nil, fmt.Errorf("no nodes supplied")
+	}
+
+	nodes := make(map[string]*Node)
+	for _, config := range configs {
+		pk, err := hex.DecodeString(config.LspdPrivateKey)
+		if err != nil {
+			return nil, fmt.Errorf("hex.DecodeString(config.lspdPrivateKey=%v) error: %v", config.LspdPrivateKey, err)
+		}
+
+		eciesPrivateKey := ecies.NewPrivateKeyFromBytes(pk)
+		eciesPublicKey := eciesPrivateKey.PublicKey
+		privateKey, publicKey := btcec.PrivKeyFromBytes(pk)
+		node := &Node{
+			NodeConfig:      config,
+			PrivateKey:      privateKey,
+			PublicKey:       publicKey,
+			EciesPrivateKey: eciesPrivateKey,
+			EciesPublicKey:  eciesPublicKey,
+		}
+
+		if config.Lnd == nil && config.Cln == nil {
+			return nil, fmt.Errorf("node has to be either cln or lnd")
+		}
+
+		if config.Lnd != nil && config.Cln != nil {
+			return nil, fmt.Errorf("node cannot be both cln and lnd")
+		}
+
+		if config.Lnd != nil {
+			node.Client, err = lnd.NewLndClient(config.Lnd)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		if config.Cln != nil {
+			node.Client, err = cln.NewClnClient(config.Cln.SocketPath)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		// Make sure the nodes is available and set name and pubkey if not set
+		// in config.
+		info, err := node.Client.GetInfo()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get info from host %s", node.NodeConfig.Host)
+		}
+
+		if node.NodeConfig.Name == "" {
+			node.NodeConfig.Name = info.Alias
+		}
+
+		if node.NodeConfig.NodePubkey == "" {
+			node.NodeConfig.NodePubkey = info.Pubkey
+		}
+
+		for _, token := range config.Tokens {
+			_, exists := nodes[token]
+			if exists {
+				return nil, fmt.Errorf("cannot have multiple nodes with the same token")
+			}
+
+			nodes[token] = node
+		}
+	}
+
+	return &nodesService{
+		nodes: nodes,
+	}, nil
+}
+
+var ErrNodeNotFound = errors.New("node not found")
+
+func (s *nodesService) GetNode(token string) (*Node, error) {
+	node, ok := s.nodes[token]
+	if !ok {
+		return nil, ErrNodeNotFound
+	}
+
+	return node, nil
+}

--- a/shared/opening_service.go
+++ b/shared/opening_service.go
@@ -1,0 +1,162 @@
+package shared
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log"
+	"sort"
+	"time"
+
+	"github.com/breez/lspd/basetypes"
+	"github.com/breez/lspd/interceptor"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
+)
+
+type OpeningService interface {
+	GetFeeParamsMenu(token string, privateKey *btcec.PrivateKey) ([]*OpeningFeeParams, error)
+	ValidateOpeningFeeParams(params *OpeningFeeParams, publicKey *btcec.PublicKey) bool
+}
+
+type openingService struct {
+	store        interceptor.InterceptStore
+	nodesService NodesService
+}
+
+func NewOpeningService(
+	store interceptor.InterceptStore,
+	nodesService NodesService,
+) OpeningService {
+	return &openingService{
+		store:        store,
+		nodesService: nodesService,
+	}
+}
+
+type OpeningFeeParams struct {
+	MinFeeMsat           uint64 `json:"min_fee_msat,string"`
+	Proportional         uint32 `json:"proportional"`
+	ValidUntil           string `json:"valid_until"`
+	MinLifetime          uint32 `json:"min_lifetime"`
+	MaxClientToSelfDelay uint32 `json:"max_client_to_self_delay"`
+	Promise              string `json:"promise"`
+}
+
+func (s *openingService) GetFeeParamsMenu(token string, privateKey *btcec.PrivateKey) ([]*OpeningFeeParams, error) {
+	var menu []*OpeningFeeParams
+	settings, err := s.store.GetFeeParamsSettings(token)
+	if err != nil {
+		log.Printf("Failed to fetch fee params settings: %v", err)
+		return nil, fmt.Errorf("failed to get opening_fee_params")
+	}
+
+	for _, setting := range settings {
+		validUntil := time.Now().UTC().Add(setting.Validity)
+		params := &OpeningFeeParams{
+			MinFeeMsat:           setting.Params.MinMsat,
+			Proportional:         setting.Params.Proportional,
+			ValidUntil:           validUntil.Format(basetypes.TIME_FORMAT),
+			MinLifetime:          setting.Params.MaxIdleTime,
+			MaxClientToSelfDelay: setting.Params.MaxClientToSelfDelay,
+		}
+
+		promise, err := createPromise(privateKey, params)
+		if err != nil {
+			log.Printf("Failed to create promise: %v", err)
+			return nil, err
+		}
+
+		params.Promise = *promise
+		menu = append(menu, params)
+	}
+
+	sort.Slice(menu, func(i, j int) bool {
+		if menu[i].MinFeeMsat == menu[j].MinFeeMsat {
+			return menu[i].Proportional < menu[j].Proportional
+		}
+
+		return menu[i].MinFeeMsat < menu[j].MinFeeMsat
+	})
+	return menu, nil
+}
+
+func (s *openingService) ValidateOpeningFeeParams(params *OpeningFeeParams, publicKey *btcec.PublicKey) bool {
+	if params == nil {
+		return false
+	}
+
+	err := verifyPromise(publicKey, params)
+	if err != nil {
+		return false
+	}
+
+	t, err := time.Parse(basetypes.TIME_FORMAT, params.ValidUntil)
+	if err != nil {
+		log.Printf("validateOpeningFeeParams: time.Parse(%v, %v) error: %v", basetypes.TIME_FORMAT, params.ValidUntil, err)
+		return false
+	}
+
+	if time.Now().UTC().After(t) {
+		log.Printf("validateOpeningFeeParams: promise not valid anymore: %v", t)
+		return false
+	}
+
+	return true
+}
+
+func createPromise(lspPrivateKey *btcec.PrivateKey, params *OpeningFeeParams) (*string, error) {
+	hash, err := paramsHash(params)
+	if err != nil {
+		return nil, err
+	}
+	// Sign the hash with the private key of the LSP id.
+	sig, err := ecdsa.SignCompact(lspPrivateKey, hash[:], true)
+	if err != nil {
+		log.Printf("createPromise: SignCompact error: %v", err)
+		return nil, err
+	}
+	promise := hex.EncodeToString(sig)
+	return &promise, nil
+}
+
+func paramsHash(params *OpeningFeeParams) ([]byte, error) {
+	// First hash all the values in the params in a fixed order.
+	items := []interface{}{
+		params.MinFeeMsat,
+		params.Proportional,
+		params.ValidUntil,
+		params.MinLifetime,
+		params.MaxClientToSelfDelay,
+	}
+	blob, err := json.Marshal(items)
+	if err != nil {
+		log.Printf("paramsHash error: %v", err)
+		return nil, err
+	}
+	hash := sha256.Sum256(blob)
+	return hash[:], nil
+}
+
+func verifyPromise(lspPublicKey *btcec.PublicKey, params *OpeningFeeParams) error {
+	hash, err := paramsHash(params)
+	if err != nil {
+		return err
+	}
+	sig, err := hex.DecodeString(params.Promise)
+	if err != nil {
+		log.Printf("verifyPromise: hex.DecodeString error: %v", err)
+		return err
+	}
+	pub, _, err := ecdsa.RecoverCompact(sig, hash)
+	if err != nil {
+		log.Printf("verifyPromise: RecoverCompact(%x) error: %v", sig, err)
+		return err
+	}
+	if !lspPublicKey.IsEqual(pub) {
+		log.Print("verifyPromise: not signed by us", err)
+		return fmt.Errorf("invalid promise")
+	}
+	return nil
+}


### PR DESCRIPTION
Order of pull requests:
1) https://github.com/breez/lspd/pull/114
2) https://github.com/breez/lspd/pull/115
3) (this PR) https://github.com/breez/lspd/pull/116
4) https://github.com/breez/lspd/pull/120

Implements `lsps2.get_info`.
Logic for handling nodes/lsp and logic for creation of opening_fee_params is put in the `shared` folder.
Implement the method `lsps2.get_info`, that creates params and returns them to the client.

Needs 2 new settings on the node: `minPaymentSizeMsat` and `maxPaymentSizeMsat`.


Potential changes:
- We could choose to put `minPaymentSizeMsat` and `maxPaymentSizeMsat` in the database, to differentiate these based on the used token.
- Another thing we can do in `get_info` is persist the token together with the generated promises. That way the `buy` requests can be correlated with the used token as well.