### PR TITLE
Implement lsps2.buy

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -139,7 +139,8 @@ jobs:
         test: [
           testLsps0GetProtocolVersions,
           testLsps2GetVersions,
-          testLsps2GetInfo
+          testLsps2GetInfo,
+          testLsps2Buy
         ]
         implementation: [
           CLN

--- a/itest/lspd_test.go
+++ b/itest/lspd_test.go
@@ -179,4 +179,8 @@ var allTestCases = []*testCase{
 		name: "testLsps2GetInfo",
 		test: testLsps2GetInfo,
 	},
+	{
+		name: "testLsps2Buy",
+		test: testLsps2Buy,
+	},
 }

--- a/itest/lsps2_buy_test.go
+++ b/itest/lsps2_buy_test.go
@@ -1,0 +1,88 @@
+package itest
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"log"
+	"time"
+
+	"github.com/breez/lntest"
+	"github.com/breez/lspd/lsps0"
+)
+
+func testLsps2Buy(p *testParams) {
+	SetFeeParams(p.Lsp(), []*FeeParamSetting{
+		{
+			Validity:     time.Second * 3600,
+			MinMsat:      1000000,
+			Proportional: 1000,
+		},
+	})
+	p.BreezClient().Node().ConnectPeer(p.Lsp().LightningNode())
+
+	p.BreezClient().Node().SendCustomMessage(&lntest.CustomMsgRequest{
+		PeerId: hex.EncodeToString(p.Lsp().NodeId()),
+		Type:   lsps0.Lsps0MessageType,
+		Data: []byte(`{
+			"method": "lsps2.get_info",
+			"jsonrpc": "2.0",
+			"id": "example#3cad6a54d302edba4c9ade2f7ffac098",
+			"params": {
+				"version": 1,
+				"token": "hello"
+			}
+		  }`),
+	})
+
+	resp := p.BreezClient().ReceiveCustomMessage()
+	log.Print(string(resp.Data))
+
+	type params struct {
+		MinFeeMsat           uint64 `json:"min_fee_msat,string"`
+		Proportional         uint32 `json:"proportional"`
+		ValidUntil           string `json:"valid_until"`
+		MinLifetime          uint32 `json:"min_lifetime"`
+		MaxClientToSelfDelay uint32 `json:"max_client_to_self_delay"`
+		Promise              string `json:"promise"`
+	}
+	data := new(struct {
+		Result struct {
+			Menu       []params `json:"opening_fee_params_menu"`
+			MinPayment uint64   `json:"min_payment_size_msat,string"`
+			MaxPayment uint64   `json:"max_payment_size_msat,string"`
+		} `json:"result"`
+	})
+	err := json.Unmarshal(resp.Data[:], &data)
+	lntest.CheckError(p.t, err)
+
+	pr, err := json.Marshal(&data.Result.Menu[0])
+	lntest.CheckError(p.t, err)
+	p.BreezClient().Node().SendCustomMessage(&lntest.CustomMsgRequest{
+		PeerId: hex.EncodeToString(p.Lsp().NodeId()),
+		Type:   lsps0.Lsps0MessageType,
+		Data: append(append(
+			[]byte(`{
+			"method": "lsps2.get_info",
+			"jsonrpc": "2.0",
+			"id": "example#3cad6a54d302edba4c9ade2f7ffac098",
+			"params": {
+				"version": 1,
+				"payment_size_msat": "42000",
+				"opening_fee_params":`),
+			pr...),
+			[]byte(`}}`)...,
+		),
+	})
+
+	buyResp := p.BreezClient().ReceiveCustomMessage()
+	log.Print(string(resp.Data))
+	b := new(struct {
+		Result struct {
+			Jit_channel_scid      string `json:"jit_channel_scid"`
+			Lsp_cltv_expiry_delta uint32 `json:"lsp_cltv_expiry_delta"`
+			Client_trusts_lsp     bool   `json:"client_trusts_lsp"`
+		} `json:"result"`
+	})
+	err = json.Unmarshal(buyResp.Data, b)
+	lntest.CheckError(p.t, err)
+}

--- a/lsps0/server.go
+++ b/lsps0/server.go
@@ -23,6 +23,10 @@ var BadMessageFormatError string = "bad message format"
 var InternalError string = "internal error"
 var MaxSimultaneousRequests = 25
 
+type ContextKey string
+
+var PeerContextKey = ContextKey("peerId")
+
 // ServiceDesc and is constructed from it for internal purposes.
 type serviceInfo struct {
 	// Contains the implementation for the methods in this service.
@@ -139,8 +143,11 @@ func (s *Server) Serve(lis lightning.CustomMsgClient) error {
 			// another simultaneous request.
 			defer func() { <-guard }()
 
+			ctx := context.Background()
+			ctx = context.WithValue(ctx, PeerContextKey, msg.PeerId)
+
 			// Call the method handler for the requested method.
-			r, err := m.method.Handler(m.service.serviceImpl, context.TODO(), df)
+			r, err := m.method.Handler(m.service.serviceImpl, ctx, df)
 			if err != nil {
 				s, ok := status.FromError(err)
 				if !ok {

--- a/lsps2/fee.go
+++ b/lsps2/fee.go
@@ -1,0 +1,42 @@
+package lsps2
+
+import "fmt"
+
+var ErrOverflow = fmt.Errorf("integer overflow detected")
+
+func computeOpeningFee(paymentSizeMsat uint64, proportional uint32, minFeeMsat uint64) (uint64, error) {
+	tmp, err := safeMultiply(paymentSizeMsat, uint64(proportional))
+	if err != nil {
+		return 0, err
+	}
+
+	tmp, err = safeAdd(tmp, 999_999)
+	if err != nil {
+		return 0, err
+	}
+
+	openingFee := tmp / 1_000_000
+	if openingFee < minFeeMsat {
+		openingFee = minFeeMsat
+	}
+
+	return openingFee, nil
+}
+
+func safeAdd(a uint64, b uint64) (uint64, error) {
+	sum := a + b
+	if sum < a {
+		return 0, ErrOverflow
+	}
+
+	return sum, nil
+}
+
+func safeMultiply(a uint64, b uint64) (uint64, error) {
+	prod := a * b
+	if a != 0 && ((prod / a) != b) {
+		return 0, ErrOverflow
+	}
+
+	return prod, nil
+}

--- a/lsps2/fee_test.go
+++ b/lsps2/fee_test.go
@@ -1,0 +1,41 @@
+package lsps2
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_FeeVariant(t *testing.T) {
+	zero := uint64(0)
+	tests := []struct {
+		paymentSizeMsat uint64
+		proportional    uint32
+		minFeeMsat      uint64
+		err             error
+		expected        uint64
+	}{
+		{proportional: 0, paymentSizeMsat: 0, minFeeMsat: 0, expected: 0},
+		{proportional: 0, paymentSizeMsat: 0, minFeeMsat: 1, expected: 1},
+		{proportional: 1, paymentSizeMsat: 1, minFeeMsat: 0, expected: 1},
+		{proportional: 1000, paymentSizeMsat: 10_000_000, minFeeMsat: 9999, expected: 10000},
+		{proportional: 1000, paymentSizeMsat: 10_000_000, minFeeMsat: 10000, expected: 10000},
+		{proportional: 1000, paymentSizeMsat: 10_000_000, minFeeMsat: 10001, expected: 10001},
+		{proportional: 1, paymentSizeMsat: zero - 999_999, minFeeMsat: 0, err: ErrOverflow},
+		{proportional: 1, paymentSizeMsat: zero - 1_000_000, minFeeMsat: 0, expected: 18446744073709},
+		{proportional: 2, paymentSizeMsat: zero - 1_000_000, minFeeMsat: 0, err: ErrOverflow},
+	}
+
+	for _, tst := range tests {
+		t.Run(
+			fmt.Sprintf("ps%d_prop%d_min%d", tst.paymentSizeMsat, tst.proportional, tst.minFeeMsat),
+			func(t *testing.T) {
+				res, err := computeOpeningFee(tst.paymentSizeMsat, tst.proportional, tst.minFeeMsat)
+				assert.Equal(t, tst.expected, res)
+				assert.Equal(t, tst.err, err)
+			},
+		)
+
+	}
+}

--- a/lsps2/scid.go
+++ b/lsps2/scid.go
@@ -1,0 +1,24 @@
+package lsps2
+
+import (
+	"crypto/rand"
+	"math/big"
+
+	"github.com/breez/lspd/basetypes"
+)
+
+var one = big.NewInt(1)
+var two = big.NewInt(2)
+var sixtyfour = big.NewInt(64)
+var twoPowSixtyfour = two.Exp(two, sixtyfour, nil)
+var maxUint64 = twoPowSixtyfour.Sub(twoPowSixtyfour, one)
+
+func newScid() (*basetypes.ShortChannelID, error) {
+	s, err := rand.Int(rand.Reader, maxUint64)
+	if err != nil {
+		return nil, err
+	}
+
+	scid := basetypes.ShortChannelID(s.Uint64())
+	return &scid, nil
+}

--- a/lsps2/server_test.go
+++ b/lsps2/server_test.go
@@ -2,9 +2,11 @@ package lsps2
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/breez/lspd/config"
+	"github.com/breez/lspd/lsps0"
 	"github.com/breez/lspd/lsps0/status"
 	"github.com/breez/lspd/shared"
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -25,9 +27,9 @@ func (m *mockNodesService) GetNodes() []*shared.Node {
 }
 
 type mockOpeningService struct {
-	menu  []*shared.OpeningFeeParams
-	err   error
-	valid bool
+	menu    []*shared.OpeningFeeParams
+	err     error
+	invalid bool
 }
 
 func (m *mockOpeningService) GetFeeParamsMenu(
@@ -41,29 +43,43 @@ func (m *mockOpeningService) ValidateOpeningFeeParams(
 	params *shared.OpeningFeeParams,
 	publicKey *btcec.PublicKey,
 ) bool {
-	return m.valid
+	return !m.invalid
+}
+
+type mockLsps2Store struct {
+	err error
+	req *RegisterBuy
+}
+
+func (s *mockLsps2Store) RegisterBuy(ctx context.Context, req *RegisterBuy) error {
+	s.req = req
+	return s.err
 }
 
 var token = "blah"
-var node = &shared.Node{
-	NodeConfig: &config.NodeConfig{
-		MinPaymentSizeMsat: 123,
-		MaxPaymentSizeMsat: 456,
-	},
+var node = func() *shared.Node {
+	return &shared.Node{
+		NodeConfig: &config.NodeConfig{
+			MinPaymentSizeMsat: 1000,
+			MaxPaymentSizeMsat: 10000,
+			TimeLockDelta:      143,
+		},
+	}
 }
 
 func Test_GetInfo_UnsupportedVersion(t *testing.T) {
 	n := &mockNodesService{}
 	o := &mockOpeningService{}
-	s := NewLsps2Server(o, n, nil)
+	st := &mockLsps2Store{}
+	s := NewLsps2Server(o, n, nil, st)
 	_, err := s.GetInfo(context.Background(), &GetInfoRequest{
 		Version: 2,
 		Token:   &token,
 	})
 
-	st := status.Convert(err)
-	assert.Equal(t, uint32(1), uint32(st.Code))
-	assert.Equal(t, "unsupported_version", st.Message)
+	status := status.Convert(err)
+	assert.Equal(t, uint32(1), uint32(status.Code))
+	assert.Equal(t, "unsupported_version", status.Message)
 }
 
 func Test_GetInfo_InvalidToken(t *testing.T) {
@@ -71,21 +87,24 @@ func Test_GetInfo_InvalidToken(t *testing.T) {
 		err: shared.ErrNodeNotFound,
 	}
 	o := &mockOpeningService{}
-	s := NewLsps2Server(o, n, nil)
+	st := &mockLsps2Store{}
+	s := NewLsps2Server(o, n, nil, st)
 	_, err := s.GetInfo(context.Background(), &GetInfoRequest{
 		Version: 1,
 		Token:   &token,
 	})
 
-	st := status.Convert(err)
-	assert.Equal(t, uint32(2), uint32(st.Code))
-	assert.Equal(t, "unrecognized_or_stale_token", st.Message)
+	status := status.Convert(err)
+	assert.Equal(t, uint32(2), uint32(status.Code))
+	assert.Equal(t, "unrecognized_or_stale_token", status.Message)
 }
 
 func Test_GetInfo_EmptyMenu(t *testing.T) {
+	node := node()
 	n := &mockNodesService{node: node}
 	o := &mockOpeningService{menu: []*shared.OpeningFeeParams{}}
-	s := NewLsps2Server(o, n, node)
+	st := &mockLsps2Store{}
+	s := NewLsps2Server(o, n, node, st)
 	resp, err := s.GetInfo(context.Background(), &GetInfoRequest{
 		Version: 1,
 		Token:   &token,
@@ -98,6 +117,7 @@ func Test_GetInfo_EmptyMenu(t *testing.T) {
 }
 
 func Test_GetInfo_PopulatedMenu_Ordered(t *testing.T) {
+	node := node()
 	n := &mockNodesService{node: node}
 	o := &mockOpeningService{menu: []*shared.OpeningFeeParams{
 		{
@@ -117,7 +137,8 @@ func Test_GetInfo_PopulatedMenu_Ordered(t *testing.T) {
 			Promise:              "d",
 		},
 	}}
-	s := NewLsps2Server(o, n, node)
+	st := &mockLsps2Store{}
+	s := NewLsps2Server(o, n, node, st)
 	resp, err := s.GetInfo(context.Background(), &GetInfoRequest{
 		Version: 1,
 		Token:   &token,
@@ -142,4 +163,182 @@ func Test_GetInfo_PopulatedMenu_Ordered(t *testing.T) {
 
 	assert.Equal(t, node.NodeConfig.MinPaymentSizeMsat, resp.MinPaymentSizeMsat)
 	assert.Equal(t, node.NodeConfig.MaxPaymentSizeMsat, resp.MaxPaymentSizeMsat)
+}
+
+func Test_Buy_UnsupportedVersion(t *testing.T) {
+	n := &mockNodesService{}
+	o := &mockOpeningService{}
+	st := &mockLsps2Store{}
+	s := NewLsps2Server(o, n, nil, st)
+	_, err := s.Buy(context.Background(), &BuyRequest{
+		Version: 2,
+	})
+
+	status := status.Convert(err)
+	assert.Equal(t, uint32(1), uint32(status.Code))
+	assert.Equal(t, "unsupported_version", status.Message)
+}
+
+func Test_Buy_InvalidFeeParams(t *testing.T) {
+	node := node()
+	n := &mockNodesService{}
+	o := &mockOpeningService{
+		invalid: true,
+	}
+	st := &mockLsps2Store{}
+	s := NewLsps2Server(o, n, node, st)
+	_, err := s.Buy(context.Background(), &BuyRequest{
+		Version: 1,
+		OpeningFeeParams: OpeningFeeParams{
+			MinFeeMsat:           1,
+			Proportional:         2,
+			ValidUntil:           "2023-08-18T13:39:00.000Z",
+			MinLifetime:          3,
+			MaxClientToSelfDelay: 4,
+			Promise:              "fake",
+		},
+	})
+
+	status := status.Convert(err)
+	assert.Equal(t, uint32(2), uint32(status.Code))
+	assert.Equal(t, "invalid_opening_fee_params", status.Message)
+}
+
+func Test_Buy_PaymentSize(t *testing.T) {
+	tests := []struct {
+		minFeeMsat  uint64
+		paymentSize uint64
+		success     bool
+		code        uint32
+		message     string
+	}{
+		{
+			minFeeMsat:  0,
+			paymentSize: 999,
+			success:     false,
+			code:        3,
+			message:     "payment_size_too_small",
+		},
+		{
+			minFeeMsat:  0,
+			paymentSize: 1000,
+			success:     true,
+		},
+		{
+			minFeeMsat:  0,
+			paymentSize: 1001,
+			success:     true,
+		},
+		{
+			minFeeMsat:  0,
+			paymentSize: 9999,
+			success:     true,
+		},
+		{
+			minFeeMsat:  0,
+			paymentSize: 10000,
+			success:     true,
+		},
+		{
+			minFeeMsat:  0,
+			paymentSize: 10001,
+			success:     false,
+			code:        4,
+			message:     "payment_size_too_large",
+		},
+		{
+			minFeeMsat:  2000,
+			paymentSize: 1999,
+			success:     false,
+			code:        3,
+			message:     "payment_size_too_small",
+		},
+		{
+			minFeeMsat:  2000,
+			paymentSize: 2000,
+			success:     false,
+			code:        3,
+			message:     "payment_size_too_small",
+		},
+		{
+			minFeeMsat:  2000,
+			paymentSize: 2001,
+			success:     true,
+		},
+	}
+
+	for _, c := range tests {
+		t.Run(
+			fmt.Sprintf("paymentsize_%d", c.paymentSize),
+			func(t *testing.T) {
+				node := node()
+				n := &mockNodesService{}
+				o := &mockOpeningService{}
+				st := &mockLsps2Store{}
+				s := NewLsps2Server(o, n, node, st)
+				ctx := context.WithValue(context.Background(), lsps0.PeerContextKey, "peer id")
+				_, err := s.Buy(ctx, &BuyRequest{
+					Version: 1,
+					OpeningFeeParams: OpeningFeeParams{
+						MinFeeMsat:           c.minFeeMsat,
+						Proportional:         2,
+						ValidUntil:           "2023-08-18T13:39:00.000Z",
+						MinLifetime:          3,
+						MaxClientToSelfDelay: 4,
+						Promise:              "fake",
+					},
+					PaymentSizeMsat: &c.paymentSize,
+				})
+
+				if c.success {
+					assert.NoError(t, err)
+				} else {
+					assert.Error(t, err)
+					status := status.Convert(err)
+					assert.Equal(t, uint32(c.code), uint32(status.Code))
+					assert.Equal(t, c.message, status.Message)
+				}
+			},
+		)
+	}
+}
+
+func Test_Buy_Registered(t *testing.T) {
+	node := node()
+	n := &mockNodesService{}
+	o := &mockOpeningService{}
+	st := &mockLsps2Store{}
+	s := NewLsps2Server(o, n, node, st)
+	paymentSize := uint64(1000)
+	peerid := "peer id"
+	ctx := context.WithValue(context.Background(), lsps0.PeerContextKey, peerid)
+	resp, _ := s.Buy(ctx, &BuyRequest{
+		Version: 1,
+		OpeningFeeParams: OpeningFeeParams{
+			MinFeeMsat:           1,
+			Proportional:         2,
+			ValidUntil:           "2023-08-18T13:39:00.000Z",
+			MinLifetime:          3,
+			MaxClientToSelfDelay: 4,
+			Promise:              "fake",
+		},
+		PaymentSizeMsat: &paymentSize,
+	})
+
+	assert.NotNil(t, st.req)
+	assert.Equal(t, node.NodeConfig.NodePubkey, st.req.LspId)
+	assert.Equal(t, peerid, st.req.PeerId)
+	assert.Equal(t, OpeningMode_MppFixedInvoice, st.req.Mode)
+	assert.Equal(t, &paymentSize, st.req.PaymentSizeMsat)
+	assert.NotZero(t, uint64(st.req.Scid))
+	assert.Equal(t, uint64(1), st.req.OpeningFeeParams.MinFeeMsat)
+	assert.Equal(t, uint32(2), st.req.OpeningFeeParams.Proportional)
+	assert.Equal(t, "2023-08-18T13:39:00.000Z", st.req.OpeningFeeParams.ValidUntil)
+	assert.Equal(t, uint32(3), st.req.OpeningFeeParams.MinLifetime)
+	assert.Equal(t, uint32(4), st.req.OpeningFeeParams.MaxClientToSelfDelay)
+	assert.Equal(t, "fake", st.req.OpeningFeeParams.Promise)
+
+	assert.Equal(t, st.req.Scid.ToString(), resp.JitChannelScid)
+	assert.Equal(t, false, resp.ClientTrustsLsp)
+	assert.Equal(t, uint32(143), resp.LspCltvExpiryDelta)
 }

--- a/lsps2/store.go
+++ b/lsps2/store.go
@@ -1,0 +1,24 @@
+package lsps2
+
+import (
+	"context"
+	"errors"
+
+	"github.com/breez/lspd/basetypes"
+	"github.com/breez/lspd/shared"
+)
+
+type RegisterBuy struct {
+	LspId            string
+	PeerId           string
+	Scid             basetypes.ShortChannelID
+	OpeningFeeParams shared.OpeningFeeParams
+	PaymentSizeMsat  *uint64
+	Mode             OpeningMode
+}
+
+var ErrScidExists = errors.New("scid exists")
+
+type Lsps2Store interface {
+	RegisterBuy(ctx context.Context, req *RegisterBuy) error
+}

--- a/main.go
+++ b/main.go
@@ -87,6 +87,7 @@ func main() {
 	interceptStore := postgresql.NewPostgresInterceptStore(pool)
 	forwardingStore := postgresql.NewForwardingEventStore(pool)
 	notificationsStore := postgresql.NewNotificationsStore(pool)
+	lsps2Store := postgresql.NewLsps2Store(pool)
 	notificationService := notifications.NewNotificationService(notificationsStore)
 
 	openingService := shared.NewOpeningService(interceptStore, nodesService)
@@ -125,7 +126,7 @@ func main() {
 			go msgClient.Start()
 			msgServer := lsps0.NewServer()
 			protocolServer := lsps0.NewProtocolServer([]uint32{2})
-			lsps2Server := lsps2.NewLsps2Server(openingService, nodesService, node)
+			lsps2Server := lsps2.NewLsps2Server(openingService, nodesService, node, lsps2Store)
 			lsps0.RegisterProtocolServer(msgServer, protocolServer)
 			lsps2.RegisterLsps2Server(msgServer, lsps2Server)
 			msgClient.WaitStarted()

--- a/postgresql/lsps2_store.go
+++ b/postgresql/lsps2_store.go
@@ -1,0 +1,60 @@
+package postgresql
+
+import (
+	"context"
+	"strings"
+
+	"github.com/breez/lspd/lsps2"
+	"github.com/jackc/pgx/v4/pgxpool"
+)
+
+type Lsps2Store struct {
+	pool *pgxpool.Pool
+}
+
+func NewLsps2Store(pool *pgxpool.Pool) *Lsps2Store {
+	return &Lsps2Store{pool: pool}
+}
+
+func (s *Lsps2Store) RegisterBuy(
+	ctx context.Context,
+	req *lsps2.RegisterBuy,
+) error {
+	_, err := s.pool.Exec(
+		ctx,
+		`INSERT INTO lsps2.buy_registrations (
+			lsp_id
+		 ,  peer_id
+		 ,  scid
+		 ,  mode
+		 ,  payment_size_msat
+		 ,  params_min_fee_msat
+		 ,  params_proportional
+		 ,  params_valid_until
+		 ,  params_min_lifetime
+		 ,  params_max_client_to_self_delay
+		 ,  params_promise
+		 )
+		 VALUES ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?`,
+		req.LspId,
+		req.PeerId,
+		int64(uint64(req.Scid)),
+		int(req.Mode),
+		req.PaymentSizeMsat,
+		int64(req.OpeningFeeParams.MinFeeMsat),
+		req.OpeningFeeParams.Proportional,
+		req.OpeningFeeParams.ValidUntil,
+		req.OpeningFeeParams.MinLifetime,
+		req.OpeningFeeParams.MaxClientToSelfDelay,
+		req.OpeningFeeParams.Promise,
+	)
+	if err != nil {
+		if strings.Contains(err.Error(), "idx_lsps2_buy_registrations_scid") {
+			return lsps2.ErrScidExists
+		}
+
+		return err
+	}
+
+	return nil
+}

--- a/postgresql/migrations/000014_lsps2_buy.down.sql
+++ b/postgresql/migrations/000014_lsps2_buy.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX idx_lsps2_buy_registrations_valid_until;
+DROP INDEX idx_lsps2_buy_registrations_scid;
+DROP TABLE lsps2.buy_registrations;
+DROP SCHEMA lsps2;

--- a/postgresql/migrations/000014_lsps2_buy.up.sql
+++ b/postgresql/migrations/000014_lsps2_buy.up.sql
@@ -1,0 +1,17 @@
+CREATE SCHEMA lsps2;
+CREATE TABLE lsps2.buy_registrations (
+    id bigserial PRIMARY KEY, 
+    lsp_id bytea NOT NULL,
+    peer_id bytea NOT NULL,
+    scid bigint NOT NULL,
+	mode smallint NOT NULL,
+	payment_size_msat bigint NULL,
+    params_min_fee_msat bigint NOT NULL,
+	params_proportional bigint NOT NULL,
+	params_valid_until varchar NOT NULL,
+	params_min_lifetime bigint NOT NULL,
+	params_max_client_to_self_delay bigint NOT NULL,
+	params_promise varchar NOT NULL
+);
+CREATE UNIQUE INDEX idx_lsps2_buy_registrations_scid ON lsps2.buy_registrations (scid);
+CREATE INDEX idx_lsps2_buy_registrations_valid_until ON lsps2.buy_registrations (params_valid_until);


### PR DESCRIPTION
1) https://github.com/breez/lspd/pull/114
2) https://github.com/breez/lspd/pull/115
3) https://github.com/breez/lspd/pull/116
4) (this PR) https://github.com/breez/lspd/pull/120

Implement `lsps2.buy`. 
Persists the lsps2 buy registrations (equivalent of `register payment`) with necessary fields to forward htlcs and open channels in a new table.