### PR TITLE
Lsps2 forwarding

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -137,7 +137,11 @@ jobs:
           testLsps0GetProtocolVersions,
           testLsps2GetVersions,
           testLsps2GetInfo,
-          testLsps2Buy
+          testLsps2Buy,
+          testLsps2HappyFlow,
+          testLsps2Cltv,
+          testLsps2NoBalance,
+          testLsps2ZeroConfUtxo
         ]
         implementation: [
           CLN

--- a/channel_opener_server.go
+++ b/channel_opener_server.go
@@ -157,11 +157,11 @@ func (s *channelOpenerServer) RegisterPayment(
 		log.Printf("checkPayment(%v, %v) error: %v", pi.IncomingAmountMsat, pi.OutgoingAmountMsat, err)
 		return nil, fmt.Errorf("checkPayment(%v, %v) error: %v", pi.IncomingAmountMsat, pi.OutgoingAmountMsat, err)
 	}
-	params := &interceptor.OpeningFeeParams{
-		MinMsat:              pi.OpeningFeeParams.MinMsat,
+	params := &shared.OpeningFeeParams{
+		MinFeeMsat:           pi.OpeningFeeParams.MinMsat,
 		Proportional:         pi.OpeningFeeParams.Proportional,
 		ValidUntil:           pi.OpeningFeeParams.ValidUntil,
-		MaxIdleTime:          pi.OpeningFeeParams.MaxIdleTime,
+		MinLifetime:          pi.OpeningFeeParams.MaxIdleTime,
 		MaxClientToSelfDelay: pi.OpeningFeeParams.MaxClientToSelfDelay,
 		Promise:              pi.OpeningFeeParams.Promise,
 	}

--- a/channel_opener_server.go
+++ b/channel_opener_server.go
@@ -8,10 +8,10 @@ import (
 	"log"
 	"time"
 
-	"github.com/breez/lspd/basetypes"
 	"github.com/breez/lspd/btceclegacy"
 	"github.com/breez/lspd/interceptor"
 	"github.com/breez/lspd/lightning"
+	"github.com/breez/lspd/lsps0"
 	lspdrpc "github.com/breez/lspd/rpc"
 	"github.com/breez/lspd/shared"
 	ecies "github.com/ecies/go/v2"
@@ -146,7 +146,7 @@ func (s *channelOpenerServer) RegisterPayment(
 		pi.OpeningFeeParams = &lspdrpc.OpeningFeeParams{
 			MinMsat:              uint64(node.NodeConfig.ChannelMinimumFeeMsat),
 			Proportional:         uint32(node.NodeConfig.ChannelFeePermyriad * 100),
-			ValidUntil:           time.Now().UTC().Add(time.Duration(time.Hour * 24)).Format(basetypes.TIME_FORMAT),
+			ValidUntil:           time.Now().UTC().Add(time.Duration(time.Hour * 24)).Format(lsps0.TIME_FORMAT),
 			MaxIdleTime:          uint32(node.NodeConfig.MaxInactiveDuration / 600),
 			MaxClientToSelfDelay: uint32(10000),
 		}

--- a/cln/cln_client.go
+++ b/cln/cln_client.go
@@ -12,6 +12,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/elementsproject/glightning/glightning"
+	"github.com/elementsproject/glightning/jrpc2"
 	"golang.org/x/exp/slices"
 )
 
@@ -126,6 +127,10 @@ func (c *ClnClient) OpenChannel(req *lightning.OpenChannelRequest) (*wire.OutPoi
 
 	if err != nil {
 		log.Printf("CLN: client.FundChannelExt(%v, %v) error: %v", pubkey, req.CapacitySat, err)
+		rpcError, ok := err.(*jrpc2.RpcError)
+		if ok && rpcError.Code == 301 {
+			return nil, fmt.Errorf("not enough funds: %w", err)
+		}
 		return nil, err
 	}
 

--- a/cln/cln_client.go
+++ b/cln/cln_client.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/breez/lspd/basetypes"
 	"github.com/breez/lspd/lightning"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
@@ -136,7 +135,7 @@ func (c *ClnClient) OpenChannel(req *lightning.OpenChannelRequest) (*wire.OutPoi
 		return nil, err
 	}
 
-	channelPoint, err := basetypes.NewOutPoint(fundingTxId[:], uint32(fundResult.FundingTxOutputNum))
+	channelPoint, err := lightning.NewOutPoint(fundingTxId[:], uint32(fundResult.FundingTxOutputNum))
 	if err != nil {
 		log.Printf("CLN: NewOutPoint(%s, %d) error: %v", fundingTxId.String(), fundResult.FundingTxOutputNum, err)
 		return nil, err
@@ -157,12 +156,12 @@ func (c *ClnClient) GetChannel(peerID []byte, channelPoint wire.OutPoint) (*ligh
 	for _, c := range peer.Channels {
 		log.Printf("getChannel destination: %s, Short channel id: %v, local alias: %v , FundingTxID:%v, State:%v ", pubkey, c.ShortChannelId, c.Alias.Local, c.FundingTxId, c.State)
 		if slices.Contains(OPEN_STATUSES, c.State) && c.FundingTxId == fundingTxID {
-			confirmedChanID, err := basetypes.NewShortChannelIDFromString(c.ShortChannelId)
+			confirmedChanID, err := lightning.NewShortChannelIDFromString(c.ShortChannelId)
 			if err != nil {
 				fmt.Printf("NewShortChannelIDFromString %v error: %v", c.ShortChannelId, err)
 				return nil, err
 			}
-			initialChanID, err := basetypes.NewShortChannelIDFromString(c.Alias.Local)
+			initialChanID, err := lightning.NewShortChannelIDFromString(c.Alias.Local)
 			if err != nil {
 				fmt.Printf("NewShortChannelIDFromString %v error: %v", c.Alias.Local, err)
 				return nil, err
@@ -213,7 +212,7 @@ func (c *ClnClient) GetClosedChannels(nodeID string, channelPoints map[string]ui
 	lookup := make(map[string]uint64)
 	for _, c := range peer.Channels {
 		if slices.Contains(CLOSING_STATUSES, c.State) {
-			cid, err := basetypes.NewShortChannelIDFromString(c.ShortChannelId)
+			cid, err := lightning.NewShortChannelIDFromString(c.ShortChannelId)
 			if err != nil {
 				log.Printf("CLN: GetClosedChannels NewShortChannelIDFromString(%v) error: %v", c.ShortChannelId, err)
 				continue
@@ -234,7 +233,7 @@ func (c *ClnClient) GetClosedChannels(nodeID string, channelPoints map[string]ui
 	return r, nil
 }
 
-func (c *ClnClient) GetPeerId(scid *basetypes.ShortChannelID) ([]byte, error) {
+func (c *ClnClient) GetPeerId(scid *lightning.ShortChannelID) ([]byte, error) {
 	scidStr := scid.ToString()
 	peers, err := c.client.ListPeers()
 	if err != nil {

--- a/cln/cln_client.go
+++ b/cln/cln_client.go
@@ -170,6 +170,7 @@ func (c *ClnClient) GetChannel(peerID []byte, channelPoint wire.OutPoint) (*ligh
 			return &lightning.GetChannelResult{
 				InitialChannelID:   *initialChanID,
 				ConfirmedChannelID: *confirmedChanID,
+				HtlcMinimumMsat:    c.HtlcMinMilliSatoshi,
 			}, nil
 		}
 	}

--- a/cln/cln_interceptor.go
+++ b/cln/cln_interceptor.go
@@ -10,10 +10,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/breez/lspd/basetypes"
 	"github.com/breez/lspd/cln_plugin/proto"
 	"github.com/breez/lspd/config"
 	"github.com/breez/lspd/interceptor"
+	"github.com/breez/lspd/lightning"
 	sphinx "github.com/lightningnetwork/lightning-onion"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/record"
@@ -140,7 +140,7 @@ func (i *ClnHtlcInterceptor) intercept() error {
 					return
 				}
 
-				scid, err := basetypes.NewShortChannelIDFromString(request.Onion.ShortChannelId)
+				scid, err := lightning.NewShortChannelIDFromString(request.Onion.ShortChannelId)
 				if err != nil {
 					interceptorClient.Send(i.defaultResolution(request))
 					i.doneWg.Done()

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,8 @@ require (
 require (
 	github.com/Microsoft/go-winio v0.5.2 // indirect
 	github.com/Yawning/aez v0.0.0-20211027044916-e49e68abd344 // indirect
+	github.com/bahlo/generic-list-go v0.2.0 // indirect
+	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/docker/distribution v2.8.2+incompatible // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/ethereum/go-ethereum v1.10.17 // indirect
@@ -37,6 +39,7 @@ require (
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/lightninglabs/neutrino/cache v1.1.1 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-isatty v0.0.16 // indirect
 	github.com/moby/term v0.0.0-20221120202655-abb19827d345 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
@@ -153,6 +156,7 @@ require (
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 // indirect
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 // indirect
 	github.com/ulikunitz/xz v0.5.10 // indirect
+	github.com/wk8/go-ordered-map/v2 v2.1.8
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect
 	go.etcd.io/bbolt v1.3.6 // indirect

--- a/interceptor/intercept.go
+++ b/interceptor/intercept.go
@@ -13,6 +13,7 @@ import (
 	"github.com/breez/lspd/chain"
 	"github.com/breez/lspd/config"
 	"github.com/breez/lspd/lightning"
+	"github.com/breez/lspd/lsps0"
 	"github.com/breez/lspd/notifications"
 	"github.com/breez/lspd/shared"
 	"github.com/btcsuite/btcd/wire"
@@ -183,7 +184,7 @@ func (i *Interceptor) Intercept(scid *basetypes.ShortChannelID, reqPaymentHash [
 				params = &shared.OpeningFeeParams{
 					MinFeeMsat:           uint64(i.config.ChannelMinimumFeeMsat),
 					Proportional:         uint32(i.config.ChannelFeePermyriad * 100),
-					ValidUntil:           time.Now().UTC().Add(time.Duration(time.Hour * 24)).Format(basetypes.TIME_FORMAT),
+					ValidUntil:           time.Now().UTC().Add(time.Duration(time.Hour * 24)).Format(lsps0.TIME_FORMAT),
 					MinLifetime:          uint32(i.config.MaxInactiveDuration / 600),
 					MaxClientToSelfDelay: uint32(10000),
 				}
@@ -197,9 +198,9 @@ func (i *Interceptor) Intercept(scid *basetypes.ShortChannelID, reqPaymentHash [
 				}, nil
 			}
 
-			validUntil, err := time.Parse(basetypes.TIME_FORMAT, params.ValidUntil)
+			validUntil, err := time.Parse(lsps0.TIME_FORMAT, params.ValidUntil)
 			if err != nil {
-				log.Printf("time.Parse(%s, %s) failed. Failing channel open: %v", basetypes.TIME_FORMAT, params.ValidUntil, err)
+				log.Printf("time.Parse(%s, %s) failed. Failing channel open: %v", lsps0.TIME_FORMAT, params.ValidUntil, err)
 				return InterceptResult{
 					Action:      INTERCEPT_FAIL_HTLC_WITH_CODE,
 					FailureCode: FAILURE_TEMPORARY_CHANNEL_FAILURE,

--- a/interceptor/intercept.go
+++ b/interceptor/intercept.go
@@ -9,7 +9,6 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/breez/lspd/basetypes"
 	"github.com/breez/lspd/chain"
 	"github.com/breez/lspd/config"
 	"github.com/breez/lspd/lightning"
@@ -78,7 +77,7 @@ func NewInterceptor(
 	}
 }
 
-func (i *Interceptor) Intercept(scid *basetypes.ShortChannelID, reqPaymentHash []byte, reqOutgoingAmountMsat uint64, reqOutgoingExpiry uint32, reqIncomingExpiry uint32) InterceptResult {
+func (i *Interceptor) Intercept(scid *lightning.ShortChannelID, reqPaymentHash []byte, reqOutgoingAmountMsat uint64, reqOutgoingExpiry uint32, reqIncomingExpiry uint32) InterceptResult {
 	reqPaymentHashStr := hex.EncodeToString(reqPaymentHash)
 	resp, _, _ := i.payHashGroup.Do(reqPaymentHashStr, func() (interface{}, error) {
 		token, params, paymentHash, paymentSecret, destination, incomingAmountMsat, outgoingAmountMsat, channelPoint, tag, err := i.store.PaymentInfo(reqPaymentHash)

--- a/interceptor/store.go
+++ b/interceptor/store.go
@@ -3,26 +3,13 @@ package interceptor
 import (
 	"time"
 
+	"github.com/breez/lspd/shared"
 	"github.com/btcsuite/btcd/wire"
 )
 
-type OpeningFeeParamsSetting struct {
-	Validity time.Duration
-	Params   *OpeningFeeParams
-}
-type OpeningFeeParams struct {
-	MinMsat              uint64 `json:"min_msat,string"`
-	Proportional         uint32 `json:"proportional"`
-	ValidUntil           string `json:"valid_until"`
-	MaxIdleTime          uint32 `json:"max_idle_time"`
-	MaxClientToSelfDelay uint32 `json:"max_client_to_self_delay"`
-	Promise              string `json:"promise"`
-}
-
 type InterceptStore interface {
-	PaymentInfo(htlcPaymentHash []byte) (string, *OpeningFeeParams, []byte, []byte, []byte, int64, int64, *wire.OutPoint, *string, error)
+	PaymentInfo(htlcPaymentHash []byte) (string, *shared.OpeningFeeParams, []byte, []byte, []byte, int64, int64, *wire.OutPoint, *string, error)
 	SetFundingTx(paymentHash []byte, channelPoint *wire.OutPoint) error
-	RegisterPayment(token string, params *OpeningFeeParams, destination, paymentHash, paymentSecret []byte, incomingAmountMsat, outgoingAmountMsat int64, tag string) error
+	RegisterPayment(token string, params *shared.OpeningFeeParams, destination, paymentHash, paymentSecret []byte, incomingAmountMsat, outgoingAmountMsat int64, tag string) error
 	InsertChannel(initialChanID, confirmedChanId uint64, channelPoint string, nodeID []byte, lastUpdate time.Time) error
-	GetFeeParamsSettings(token string) ([]*OpeningFeeParamsSetting, error)
 }

--- a/itest/breez_client.go
+++ b/itest/breez_client.go
@@ -2,10 +2,16 @@ package itest
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"log"
+	"math/rand"
 	"testing"
 
 	"github.com/breez/lntest"
+	"github.com/breez/lspd/lsps0"
+	"github.com/breez/lspd/lsps0/jsonrpc"
+	"github.com/breez/lspd/lsps2"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/btcsuite/btcd/chaincfg"
@@ -39,6 +45,18 @@ type invoice struct {
 }
 
 func GenerateInvoices(n BreezClient, req generateInvoicesRequest) (invoice, invoice) {
+	return generateInvoices(n, req, lntest.ShortChannelID{
+		BlockHeight: 1,
+		TxIndex:     0,
+		OutputIndex: 0,
+	}, lspCltvDelta)
+}
+
+func GenerateLsps2Invoices(n BreezClient, req generateInvoicesRequest, scid string) (invoice, invoice) {
+	return generateInvoices(n, req, lntest.NewShortChanIDFromString(scid), lspCltvDelta+2)
+}
+
+func generateInvoices(n BreezClient, req generateInvoicesRequest, scid lntest.ShortChannelID, cltvDelta uint16) (invoice, invoice) {
 	preimage, err := GenerateRandomBytes(32)
 	lntest.CheckError(n.Harness().T, err)
 
@@ -47,11 +65,7 @@ func GenerateInvoices(n BreezClient, req generateInvoicesRequest) (invoice, invo
 		Description: &req.description,
 		Preimage:    &preimage,
 	})
-	outerInvoice := AddHopHint(n, innerInvoice.Bolt11, req.lsp, lntest.ShortChannelID{
-		BlockHeight: 1,
-		TxIndex:     0,
-		OutputIndex: 0,
-	}, &req.outerAmountMsat)
+	outerInvoice := AddHopHint(n, innerInvoice.Bolt11, req.lsp, scid, &req.outerAmountMsat, cltvDelta)
 
 	inner := invoice{
 		bolt11:          innerInvoice.Bolt11,
@@ -76,7 +90,7 @@ func ContainsHopHint(t *testing.T, invoice string) bool {
 	return len(rawInvoice.RouteHints) > 0
 }
 
-func AddHopHint(n BreezClient, invoice string, lsp LspNode, chanid lntest.ShortChannelID, amountMsat *uint64) string {
+func AddHopHint(n BreezClient, invoice string, lsp LspNode, chanid lntest.ShortChannelID, amountMsat *uint64, cltvDelta uint16) string {
 	rawInvoice, err := zpay32.Decode(invoice, &chaincfg.RegressionNetParams)
 	lntest.CheckError(n.Harness().T, err)
 
@@ -93,7 +107,7 @@ func AddHopHint(n BreezClient, invoice string, lsp LspNode, chanid lntest.ShortC
 			ChannelID:                 chanid.ToUint64(),
 			FeeBaseMSat:               lspBaseFeeMsat,
 			FeeProportionalMillionths: lspFeeRatePpm,
-			CLTVExpiryDelta:           lspCltvDelta,
+			CLTVExpiryDelta:           cltvDelta,
 		},
 	})
 
@@ -120,4 +134,68 @@ func AddHopHint(n BreezClient, invoice string, lsp LspNode, chanid lntest.ShortC
 	lntest.CheckError(n.Harness().T, err)
 
 	return newInvoice
+}
+
+func Lsps2GetInfo(c BreezClient, l LspNode, req lsps2.GetInfoRequest) lsps2.GetInfoResponse {
+	req.Version = lsps2.SupportedVersion
+	r := lsps2RequestResponse(c, l, "lsps2.get_info", req)
+	var resp lsps2.GetInfoResponse
+	err := json.Unmarshal(r, &resp)
+	lntest.CheckError(c.Harness().T, err)
+
+	return resp
+}
+
+func Lsps2Buy(c BreezClient, l LspNode, req lsps2.BuyRequest) lsps2.BuyResponse {
+	req.Version = lsps2.SupportedVersion
+	r := lsps2RequestResponse(c, l, "lsps2.buy", req)
+	var resp lsps2.BuyResponse
+	err := json.Unmarshal(r, &resp)
+	lntest.CheckError(c.Harness().T, err)
+
+	return resp
+}
+
+func lsps2RequestResponse(c BreezClient, l LspNode, method string, req interface{}) []byte {
+	id := RandStringBytes(32)
+	peerId := hex.EncodeToString(l.NodeId())
+	inner, err := json.Marshal(req)
+	lntest.CheckError(c.Harness().T, err)
+	outer, err := json.Marshal(&jsonrpc.Request{
+		JsonRpc: jsonrpc.Version,
+		Method:  method,
+		Id:      id,
+		Params:  inner,
+	})
+	lntest.CheckError(c.Harness().T, err)
+
+	log.Printf(string(outer))
+	c.Node().SendCustomMessage(&lntest.CustomMsgRequest{
+		PeerId: peerId,
+		Type:   lsps0.Lsps0MessageType,
+		Data:   outer,
+	})
+
+	m := c.ReceiveCustomMessage()
+	log.Printf(string(m.Data))
+
+	var resp jsonrpc.Response
+	err = json.Unmarshal(m.Data, &resp)
+	lntest.CheckError(c.Harness().T, err)
+
+	if resp.Id != id {
+		c.Harness().T.Fatalf("Received custom message, but had different id")
+	}
+
+	return resp.Result
+}
+
+const letterBytes = "abcdefghijklmnopqrstuvwxyz"
+
+func RandStringBytes(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+	return string(b)
 }

--- a/itest/lspd_node.go
+++ b/itest/lspd_node.go
@@ -113,6 +113,8 @@ func newLspd(h *lntest.TestHarness, mem *mempoolApi, name string, nodeConfig *co
 		ChannelMinimumFeeMsat:     2000000,
 		AdditionalChannelCapacity: 100000,
 		MaxInactiveDuration:       3888000,
+		MinPaymentSizeMsat:        600,
+		MaxPaymentSizeMsat:        4000000000,
 		Lnd:                       lnd,
 		Cln:                       cln,
 	}

--- a/itest/lspd_test.go
+++ b/itest/lspd_test.go
@@ -18,7 +18,13 @@ func TestLspd(t *testing.T) {
 		return
 	}
 	testCases := allTestCases
-	runTests(t, testCases, "LND-lspd", lndLspFunc, lndClientFunc)
+	var lndTestCases []*testCase
+	for _, c := range testCases {
+		if !c.isLsps2 {
+			lndTestCases = append(lndTestCases, c)
+		}
+	}
+	runTests(t, lndTestCases, "LND-lspd", lndLspFunc, lndClientFunc)
 	runTests(t, testCases, "CLN-lspd", clnLspFunc, clnClientFunc)
 }
 
@@ -106,6 +112,7 @@ type testCase struct {
 	name          string
 	test          func(t *testParams)
 	skipCreateLsp bool
+	isLsps2       bool
 	timeout       time.Duration
 }
 
@@ -168,19 +175,44 @@ var allTestCases = []*testCase{
 		test: testOfflineNotificationZeroConfChannel,
 	},
 	{
-		name: "testLsps0GetProtocolVersions",
-		test: testLsps0GetProtocolVersions,
+		name:    "testLsps0GetProtocolVersions",
+		test:    testLsps0GetProtocolVersions,
+		isLsps2: true,
 	},
 	{
-		name: "testLsps2GetVersions",
-		test: testLsps2GetVersions,
+		name:    "testLsps2GetVersions",
+		test:    testLsps2GetVersions,
+		isLsps2: true,
 	},
 	{
-		name: "testLsps2GetInfo",
-		test: testLsps2GetInfo,
+		name:    "testLsps2GetInfo",
+		test:    testLsps2GetInfo,
+		isLsps2: true,
 	},
 	{
-		name: "testLsps2Buy",
-		test: testLsps2Buy,
+		name:    "testLsps2Buy",
+		test:    testLsps2Buy,
+		isLsps2: true,
+	},
+	{
+		name:    "testLsps2HappyFlow",
+		test:    testLsps2HappyFlow,
+		isLsps2: true,
+	},
+	{
+		name:    "testLsps2Cltv",
+		test:    testLsps2Cltv,
+		isLsps2: true,
+	},
+	{
+		name:    "testLsps2NoBalance",
+		test:    testLsps2NoBalance,
+		isLsps2: true,
+	},
+	{
+		name:          "testLsps2ZeroConfUtxo",
+		test:          testLsps2ZeroConfUtxo,
+		isLsps2:       true,
+		skipCreateLsp: true,
 	},
 }

--- a/itest/lsps2_buy_test.go
+++ b/itest/lsps2_buy_test.go
@@ -7,7 +7,10 @@ import (
 	"time"
 
 	"github.com/breez/lntest"
+	"github.com/breez/lspd/lightning"
 	"github.com/breez/lspd/lsps0"
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/stretchr/testify/assert"
 )
 
 func testLsps2Buy(p *testParams) {
@@ -62,12 +65,12 @@ func testLsps2Buy(p *testParams) {
 		Type:   lsps0.Lsps0MessageType,
 		Data: append(append(
 			[]byte(`{
-			"method": "lsps2.get_info",
+			"method": "lsps2.buy",
 			"jsonrpc": "2.0",
-			"id": "example#3cad6a54d302edba4c9ade2f7ffac098",
+			"id": "example#3cad6a54d302edba4c9ade2f7ffac099",
 			"params": {
 				"version": 1,
-				"payment_size_msat": "42000",
+				"payment_size_msat": "42000000",
 				"opening_fee_params":`),
 			pr...),
 			[]byte(`}}`)...,
@@ -75,7 +78,7 @@ func testLsps2Buy(p *testParams) {
 	})
 
 	buyResp := p.BreezClient().ReceiveCustomMessage()
-	log.Print(string(resp.Data))
+	log.Print(string(buyResp.Data))
 	b := new(struct {
 		Result struct {
 			Jit_channel_scid      string `json:"jit_channel_scid"`
@@ -85,4 +88,37 @@ func testLsps2Buy(p *testParams) {
 	})
 	err = json.Unmarshal(buyResp.Data, b)
 	lntest.CheckError(p.t, err)
+
+	pgxPool, err := pgxpool.Connect(p.h.Ctx, p.lsp.PostgresBackend().ConnectionString())
+	if err != nil {
+		p.h.T.Fatalf("Failed to connect to postgres backend: %v", err)
+	}
+	defer pgxPool.Close()
+
+	scid, err := lightning.NewShortChannelIDFromString(b.Result.Jit_channel_scid)
+	lntest.CheckError(p.t, err)
+
+	rows, err := pgxPool.Query(
+		p.h.Ctx,
+		`SELECT token 
+		 FROM lsps2.buy_registrations
+		 WHERE scid = $1`,
+		int64(uint64(*scid)),
+	)
+	if err != nil {
+		p.h.T.Fatalf("Failed to query token: %v", err)
+	}
+
+	defer rows.Close()
+	if !rows.Next() {
+		p.h.T.Fatal("No rows found")
+	}
+
+	var actual string
+	err = rows.Scan(&actual)
+	if err != nil {
+		p.h.T.Fatalf("Failed to get token from row: %v", err)
+	}
+
+	assert.Equal(p.h.T, "hello", actual)
 }

--- a/itest/lsps2_cltv_test.go
+++ b/itest/lsps2_cltv_test.go
@@ -1,0 +1,63 @@
+package itest
+
+import (
+	"log"
+	"time"
+
+	"github.com/breez/lntest"
+	"github.com/breez/lspd/lsps2"
+	"github.com/stretchr/testify/assert"
+)
+
+func testLsps2Cltv(p *testParams) {
+	alice := lntest.NewClnNode(p.h, p.m, "Alice")
+	alice.Start()
+	alice.Fund(10000000)
+	p.lsp.LightningNode().Fund(10000000)
+
+	log.Print("Opening channel between Alice and the lsp")
+	channel := alice.OpenChannel(p.lsp.LightningNode(), &lntest.OpenChannelOptions{
+		AmountSat: publicChanAmount,
+	})
+	aliceLspScid := alice.WaitForChannelReady(channel)
+
+	log.Print("Connecting bob to lspd")
+	p.BreezClient().Node().ConnectPeer(p.lsp.LightningNode())
+
+	log.Printf("Calling lsps2.get_info")
+	info := Lsps2GetInfo(p.BreezClient(), p.Lsp(), lsps2.GetInfoRequest{
+		Token: &WorkingToken,
+	})
+
+	outerAmountMsat := uint64(2100000)
+	innerAmountMsat := lsps2CalculateInnerAmountMsat(p.lsp, outerAmountMsat, info.OpeningFeeParamsMenu[0])
+	p.BreezClient().SetHtlcAcceptor(innerAmountMsat)
+
+	log.Printf("Calling lsps2.buy")
+	buyResp := Lsps2Buy(p.BreezClient(), p.Lsp(), lsps2.BuyRequest{
+		OpeningFeeParams: *info.OpeningFeeParamsMenu[0],
+		PaymentSizeMsat:  &outerAmountMsat,
+	})
+
+	log.Printf("Adding bob's invoices")
+	description := "Please pay me"
+	_, outerInvoice := GenerateLsps2Invoices(p.BreezClient(),
+		generateInvoicesRequest{
+			innerAmountMsat: innerAmountMsat,
+			outerAmountMsat: outerAmountMsat,
+			description:     description,
+			lsp:             p.lsp,
+		},
+		buyResp.JitChannelScid)
+
+	// TODO: Fix race waiting for htlc interceptor.
+	log.Printf("Waiting %v to allow htlc interceptor to activate.", htlcInterceptorDelay)
+	<-time.After(htlcInterceptorDelay)
+	log.Printf("Alice paying")
+	route := constructRoute(p.Lsp().LightningNode(), p.BreezClient().Node(), aliceLspScid, lntest.NewShortChanIDFromString(buyResp.JitChannelScid), outerAmountMsat)
+
+	// Increment the delay by one (should be incremented by 2), so the cltv delta is too little.
+	route.Hops[0].Delay++
+	_, err := alice.PayViaRoute(outerAmountMsat, outerInvoice.paymentHash, outerInvoice.paymentSecret, route)
+	assert.Contains(p.t, err.Error(), "WIRE_INCORRECT_CLTV_EXPIRY")
+}

--- a/itest/lsps2_happy_flow_test.go
+++ b/itest/lsps2_happy_flow_test.go
@@ -1,0 +1,72 @@
+package itest
+
+import (
+	"log"
+	"time"
+
+	"github.com/breez/lntest"
+	"github.com/breez/lspd/lsps2"
+	"github.com/stretchr/testify/assert"
+)
+
+func testLsps2HappyFlow(p *testParams) {
+	alice := lntest.NewClnNode(p.h, p.m, "Alice")
+	alice.Start()
+	alice.Fund(10000000)
+	p.lsp.LightningNode().Fund(10000000)
+
+	log.Print("Opening channel between Alice and the lsp")
+	channel := alice.OpenChannel(p.lsp.LightningNode(), &lntest.OpenChannelOptions{
+		AmountSat: publicChanAmount,
+	})
+	alice.WaitForChannelReady(channel)
+
+	log.Print("Connecting bob to lspd")
+	p.BreezClient().Node().ConnectPeer(p.lsp.LightningNode())
+
+	log.Printf("Calling lsps2.get_info")
+	info := Lsps2GetInfo(p.BreezClient(), p.Lsp(), lsps2.GetInfoRequest{
+		Token: &WorkingToken,
+	})
+
+	outerAmountMsat := uint64(2100000)
+	innerAmountMsat := lsps2CalculateInnerAmountMsat(p.lsp, outerAmountMsat, info.OpeningFeeParamsMenu[0])
+	p.BreezClient().SetHtlcAcceptor(innerAmountMsat)
+
+	log.Printf("Calling lsps2.buy")
+	buyResp := Lsps2Buy(p.BreezClient(), p.Lsp(), lsps2.BuyRequest{
+		OpeningFeeParams: *info.OpeningFeeParamsMenu[0],
+		PaymentSizeMsat:  &outerAmountMsat,
+	})
+
+	log.Printf("Adding bob's invoices")
+	description := "Please pay me"
+	_, outerInvoice := GenerateLsps2Invoices(p.BreezClient(),
+		generateInvoicesRequest{
+			innerAmountMsat: innerAmountMsat,
+			outerAmountMsat: outerAmountMsat,
+			description:     description,
+			lsp:             p.lsp,
+		},
+		buyResp.JitChannelScid)
+
+	// TODO: Fix race waiting for htlc interceptor.
+	log.Printf("Waiting %v to allow htlc interceptor to activate.", htlcInterceptorDelay)
+	<-time.After(htlcInterceptorDelay)
+	log.Printf("Alice paying")
+	payResp := alice.Pay(outerInvoice.bolt11)
+	bobInvoice := p.BreezClient().Node().GetInvoice(payResp.PaymentHash)
+
+	assert.Equal(p.t, payResp.PaymentPreimage, bobInvoice.PaymentPreimage)
+	assert.Equal(p.t, innerAmountMsat, bobInvoice.AmountReceivedMsat)
+
+	// Make sure capacity is correct
+	chans := p.BreezClient().Node().GetChannels()
+	assert.Equal(p.t, 1, len(chans))
+	c := chans[0]
+	AssertChannelCapacity(p.t, innerAmountMsat, c.CapacityMsat)
+
+	assert.Equal(p.t, c.RemoteReserveMsat, c.CapacityMsat/100)
+	log.Printf("local reserve: %d, remote reserve: %d", c.LocalReserveMsat, c.RemoteReserveMsat)
+	assert.Zero(p.t, c.LocalReserveMsat)
+}

--- a/itest/lsps2_no_balance_test.go
+++ b/itest/lsps2_no_balance_test.go
@@ -1,0 +1,62 @@
+package itest
+
+import (
+	"log"
+	"time"
+
+	"github.com/breez/lntest"
+	"github.com/breez/lspd/lsps2"
+	"github.com/stretchr/testify/assert"
+)
+
+func testLsps2NoBalance(p *testParams) {
+	alice := lntest.NewClnNode(p.h, p.m, "Alice")
+	alice.Start()
+	alice.Fund(10000000)
+
+	log.Print("Opening channel between Alice and the lsp")
+	channel := alice.OpenChannel(p.lsp.LightningNode(), &lntest.OpenChannelOptions{
+		AmountSat: publicChanAmount,
+	})
+	aliceLspScid := alice.WaitForChannelReady(channel)
+
+	log.Print("Connecting bob to lspd")
+	p.BreezClient().Node().ConnectPeer(p.lsp.LightningNode())
+
+	log.Printf("Calling lsps2.get_info")
+	info := Lsps2GetInfo(p.BreezClient(), p.Lsp(), lsps2.GetInfoRequest{
+		Token: &WorkingToken,
+	})
+
+	outerAmountMsat := uint64(2100000)
+	innerAmountMsat := lsps2CalculateInnerAmountMsat(p.lsp, outerAmountMsat, info.OpeningFeeParamsMenu[0])
+	p.BreezClient().SetHtlcAcceptor(innerAmountMsat)
+
+	log.Printf("Calling lsps2.buy")
+	buyResp := Lsps2Buy(p.BreezClient(), p.Lsp(), lsps2.BuyRequest{
+		OpeningFeeParams: *info.OpeningFeeParamsMenu[0],
+		PaymentSizeMsat:  &outerAmountMsat,
+	})
+
+	log.Printf("Adding bob's invoices")
+	description := "Please pay me"
+	_, outerInvoice := GenerateLsps2Invoices(p.BreezClient(),
+		generateInvoicesRequest{
+			innerAmountMsat: innerAmountMsat,
+			outerAmountMsat: outerAmountMsat,
+			description:     description,
+			lsp:             p.lsp,
+		},
+		buyResp.JitChannelScid)
+
+	// TODO: Fix race waiting for htlc interceptor.
+	log.Printf("Waiting %v to allow htlc interceptor to activate.", htlcInterceptorDelay)
+	<-time.After(htlcInterceptorDelay)
+	log.Printf("Alice paying")
+	route := constructRoute(p.Lsp().LightningNode(), p.BreezClient().Node(), aliceLspScid, lntest.NewShortChanIDFromString(buyResp.JitChannelScid), outerAmountMsat)
+
+	// Increment the delay by two to support the spec
+	route.Hops[0].Delay += 2
+	_, err := alice.PayViaRoute(outerAmountMsat, outerInvoice.paymentHash, outerInvoice.paymentSecret, route)
+	assert.Contains(p.t, err.Error(), "WIRE_TEMPORARY_CHANNEL_FAILURE")
+}

--- a/itest/lsps2_zero_conf_utxo_test.go
+++ b/itest/lsps2_zero_conf_utxo_test.go
@@ -1,0 +1,82 @@
+package itest
+
+import (
+	"log"
+	"time"
+
+	"github.com/breez/lntest"
+	"github.com/breez/lspd/config"
+	"github.com/breez/lspd/lsps2"
+	"github.com/stretchr/testify/assert"
+)
+
+func testLsps2ZeroConfUtxo(p *testParams) {
+	alice := lntest.NewClnNode(p.h, p.m, "Alice")
+	alice.Start()
+	alice.Fund(10000000)
+
+	minConfs := uint32(0)
+	lsp := p.lspFunc(p.h, p.m, p.mem, &config.NodeConfig{MinConfs: &minConfs})
+	lsp.Start()
+
+	log.Print("Opening channel between Alice and the lsp")
+	channel := alice.OpenChannel(lsp.LightningNode(), &lntest.OpenChannelOptions{
+		AmountSat: publicChanAmount,
+	})
+	channelId := alice.WaitForChannelReady(channel)
+
+	tempaddr := lsp.LightningNode().GetNewAddress()
+	p.m.SendToAddress(tempaddr, 210000)
+	p.m.MineBlocks(6)
+	lsp.LightningNode().WaitForSync()
+
+	initialHeight := p.m.GetBlockHeight()
+	addr := lsp.LightningNode().GetNewAddress()
+	lsp.LightningNode().SendToAddress(addr, 200000)
+
+	log.Print("Connecting bob to lspd")
+	p.BreezClient().Node().ConnectPeer(lsp.LightningNode())
+
+	log.Printf("Calling lsps2.get_info")
+	info := Lsps2GetInfo(p.BreezClient(), lsp, lsps2.GetInfoRequest{
+		Token: &WorkingToken,
+	})
+
+	outerAmountMsat := uint64(2100000)
+	innerAmountMsat := lsps2CalculateInnerAmountMsat(lsp, outerAmountMsat, info.OpeningFeeParamsMenu[0])
+	p.BreezClient().SetHtlcAcceptor(innerAmountMsat)
+
+	log.Printf("Calling lsps2.buy")
+	buyResp := Lsps2Buy(p.BreezClient(), lsp, lsps2.BuyRequest{
+		OpeningFeeParams: *info.OpeningFeeParamsMenu[0],
+		PaymentSizeMsat:  &outerAmountMsat,
+	})
+
+	log.Printf("Adding bob's invoices")
+	description := "Please pay me"
+	_, outerInvoice := GenerateLsps2Invoices(p.BreezClient(),
+		generateInvoicesRequest{
+			innerAmountMsat: innerAmountMsat,
+			outerAmountMsat: outerAmountMsat,
+			description:     description,
+			lsp:             lsp,
+		},
+		buyResp.JitChannelScid)
+
+	// TODO: Fix race waiting for htlc interceptor.
+	log.Printf("Waiting %v to allow htlc interceptor to activate.", htlcInterceptorDelay)
+	<-time.After(htlcInterceptorDelay)
+	log.Printf("Alice paying")
+	route := constructRoute(lsp.LightningNode(), p.BreezClient().Node(), channelId, lntest.NewShortChanIDFromString(buyResp.JitChannelScid), outerAmountMsat)
+	route.Hops[0].Delay += 2
+	payResp, err := alice.PayViaRoute(outerAmountMsat, outerInvoice.paymentHash, outerInvoice.paymentSecret, route)
+	lntest.CheckError(p.t, err)
+	bobInvoice := p.BreezClient().Node().GetInvoice(payResp.PaymentHash)
+
+	assert.Equal(p.t, payResp.PaymentPreimage, bobInvoice.PaymentPreimage)
+	assert.Equal(p.t, innerAmountMsat, bobInvoice.AmountReceivedMsat)
+
+	// Make sure there's not accidently a block mined in between
+	finalHeight := p.m.GetBlockHeight()
+	assert.Equal(p.t, initialHeight, finalHeight)
+}

--- a/itest/notification_test.go
+++ b/itest/notification_test.go
@@ -253,7 +253,7 @@ func testOfflineNotificationZeroConfChannel(p *testParams) {
 		} else {
 			id = chans[0].ShortChannelID
 		}
-		invoiceWithHint = AddHopHint(p.BreezClient(), bobInvoice.Bolt11, p.Lsp(), id, nil)
+		invoiceWithHint = AddHopHint(p.BreezClient(), bobInvoice.Bolt11, p.Lsp(), id, nil, lspCltvDelta)
 	}
 
 	log.Printf("Invoice with hint: %s", invoiceWithHint)

--- a/itest/test_common.go
+++ b/itest/test_common.go
@@ -5,9 +5,12 @@ import (
 	"log"
 	"testing"
 
+	"github.com/breez/lspd/lsps2"
 	lspd "github.com/breez/lspd/rpc"
 	"github.com/stretchr/testify/assert"
 )
+
+var WorkingToken = "hello"
 
 func GenerateRandomBytes(n int) ([]byte, error) {
 	b := make([]byte, n)
@@ -45,6 +48,16 @@ func calculateInnerAmountMsat(lsp LspNode, outerAmountMsat uint64, params *lspd.
 
 	if fee > outerAmountMsat {
 		lsp.Harness().Fatalf("Fee is higher than amount")
+	}
+
+	log.Printf("outer: %v, fee: %v", outerAmountMsat, fee)
+	return outerAmountMsat - fee
+}
+
+func lsps2CalculateInnerAmountMsat(lsp LspNode, outerAmountMsat uint64, params *lsps2.OpeningFeeParams) uint64 {
+	fee := (outerAmountMsat*uint64(params.Proportional) + 999_999) / 1_000_000
+	if fee < params.MinFeeMsat {
+		fee = params.MinFeeMsat
 	}
 
 	log.Printf("outer: %v, fee: %v", outerAmountMsat, fee)

--- a/lightning/client.go
+++ b/lightning/client.go
@@ -3,7 +3,6 @@ package lightning
 import (
 	"time"
 
-	"github.com/breez/lspd/basetypes"
 	"github.com/btcsuite/btcd/wire"
 )
 
@@ -13,8 +12,8 @@ type GetInfoResult struct {
 }
 
 type GetChannelResult struct {
-	InitialChannelID   basetypes.ShortChannelID
-	ConfirmedChannelID basetypes.ShortChannelID
+	InitialChannelID   ShortChannelID
+	ConfirmedChannelID ShortChannelID
 	HtlcMinimumMsat    uint64
 }
 
@@ -34,7 +33,7 @@ type Client interface {
 	IsConnected(destination []byte) (bool, error)
 	OpenChannel(req *OpenChannelRequest) (*wire.OutPoint, error)
 	GetChannel(peerID []byte, channelPoint wire.OutPoint) (*GetChannelResult, error)
-	GetPeerId(scid *basetypes.ShortChannelID) ([]byte, error)
+	GetPeerId(scid *ShortChannelID) ([]byte, error)
 	GetNodeChannelCount(nodeID []byte) (int, error)
 	GetClosedChannels(nodeID string, channelPoints map[string]uint64) (map[string]uint64, error)
 	WaitOnline(peerID []byte, deadline time.Time) error

--- a/lightning/client.go
+++ b/lightning/client.go
@@ -15,6 +15,7 @@ type GetInfoResult struct {
 type GetChannelResult struct {
 	InitialChannelID   basetypes.ShortChannelID
 	ConfirmedChannelID basetypes.ShortChannelID
+	HtlcMinimumMsat    uint64
 }
 
 type OpenChannelRequest struct {

--- a/lightning/outpoint.go
+++ b/lightning/outpoint.go
@@ -1,4 +1,4 @@
-package basetypes
+package lightning
 
 import (
 	"log"

--- a/lightning/short_channel_id.go
+++ b/lightning/short_channel_id.go
@@ -1,4 +1,4 @@
-package basetypes
+package lightning
 
 import (
 	"fmt"

--- a/lnd/client.go
+++ b/lnd/client.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/breez/lspd/basetypes"
 	"github.com/breez/lspd/config"
 	"github.com/breez/lspd/lightning"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -275,7 +274,7 @@ func (c *LndClient) OpenChannel(req *lightning.OpenChannelRequest) (*wire.OutPoi
 		return nil, fmt.Errorf("LND: OpenChannel() error: %w", err)
 	}
 
-	result, err := basetypes.NewOutPoint(channelPoint.GetFundingTxidBytes(), channelPoint.OutputIndex)
+	result, err := lightning.NewOutPoint(channelPoint.GetFundingTxidBytes(), channelPoint.OutputIndex)
 	if err != nil {
 		log.Printf("LND: OpenChannel returned invalid outpoint. error: %v", err)
 		return nil, err
@@ -307,8 +306,8 @@ func (c *LndClient) GetChannel(peerID []byte, channelPoint wire.OutPoint) (*ligh
 				}
 			}
 			return &lightning.GetChannelResult{
-				InitialChannelID:   basetypes.ShortChannelID(c.ChanId),
-				ConfirmedChannelID: basetypes.ShortChannelID(confirmedChanId),
+				InitialChannelID:   lightning.ShortChannelID(c.ChanId),
+				ConfirmedChannelID: lightning.ShortChannelID(confirmedChanId),
 				HtlcMinimumMsat:    c.LocalConstraints.MinHtlcMsat,
 			}, nil
 		}
@@ -380,7 +379,7 @@ func (c *LndClient) getWaitingCloseChannels(nodeID string) ([]*lnrpc.PendingChan
 	return waitingCloseChannels, nil
 }
 
-func (c *LndClient) GetPeerId(scid *basetypes.ShortChannelID) ([]byte, error) {
+func (c *LndClient) GetPeerId(scid *lightning.ShortChannelID) ([]byte, error) {
 	scidu64 := uint64(*scid)
 	peer, err := c.client.GetPeerIdByScid(context.Background(), &lnrpc.GetPeerIdByScidRequest{
 		Scid: scidu64,

--- a/lnd/client.go
+++ b/lnd/client.go
@@ -309,6 +309,7 @@ func (c *LndClient) GetChannel(peerID []byte, channelPoint wire.OutPoint) (*ligh
 			return &lightning.GetChannelResult{
 				InitialChannelID:   basetypes.ShortChannelID(c.ChanId),
 				ConfirmedChannelID: basetypes.ShortChannelID(confirmedChanId),
+				HtlcMinimumMsat:    c.LocalConstraints.MinHtlcMsat,
 			}, nil
 		}
 	}

--- a/lnd/interceptor.go
+++ b/lnd/interceptor.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/breez/lspd/basetypes"
 	"github.com/breez/lspd/config"
 	"github.com/breez/lspd/interceptor"
+	"github.com/breez/lspd/lightning"
 	"github.com/btcsuite/btcd/btcec/v2"
 	sphinx "github.com/lightningnetwork/lightning-onion"
 	"github.com/lightningnetwork/lnd/lnrpc"
@@ -135,7 +135,7 @@ func (i *LndHtlcInterceptor) intercept() error {
 
 			i.doneWg.Add(1)
 			go func() {
-				scid := basetypes.ShortChannelID(request.OutgoingRequestedChanId)
+				scid := lightning.ShortChannelID(request.OutgoingRequestedChanId)
 				interceptResult := i.interceptor.Intercept(&scid, request.PaymentHash, request.OutgoingAmountMsat, request.OutgoingExpiry, request.IncomingExpiry)
 				switch interceptResult.Action {
 				case interceptor.INTERCEPT_RESUME_WITH_ONION:

--- a/lnd/interceptor.go
+++ b/lnd/interceptor.go
@@ -10,6 +10,7 @@ import (
 	"github.com/breez/lspd/config"
 	"github.com/breez/lspd/interceptor"
 	"github.com/breez/lspd/lightning"
+	"github.com/breez/lspd/shared"
 	"github.com/btcsuite/btcd/btcec/v2"
 	sphinx "github.com/lightningnetwork/lightning-onion"
 	"github.com/lightningnetwork/lnd/lnrpc"
@@ -136,16 +137,24 @@ func (i *LndHtlcInterceptor) intercept() error {
 			i.doneWg.Add(1)
 			go func() {
 				scid := lightning.ShortChannelID(request.OutgoingRequestedChanId)
-				interceptResult := i.interceptor.Intercept(&scid, request.PaymentHash, request.OutgoingAmountMsat, request.OutgoingExpiry, request.IncomingExpiry)
+				interceptResult := i.interceptor.Intercept(shared.InterceptRequest{
+					Identifier:         request.IncomingCircuitKey.String(),
+					Scid:               scid,
+					PaymentHash:        request.PaymentHash,
+					IncomingAmountMsat: request.IncomingAmountMsat,
+					OutgoingAmountMsat: request.OutgoingAmountMsat,
+					IncomingExpiry:     request.IncomingExpiry,
+					OutgoingExpiry:     request.OutgoingExpiry,
+				})
 				switch interceptResult.Action {
-				case interceptor.INTERCEPT_RESUME_WITH_ONION:
+				case shared.INTERCEPT_RESUME_WITH_ONION:
 					onion, err := i.constructOnion(interceptResult, request.OutgoingExpiry, request.PaymentHash)
 					if err == nil {
 						interceptorClient.Send(&routerrpc.ForwardHtlcInterceptResponse{
 							IncomingCircuitKey:      request.IncomingCircuitKey,
 							Action:                  routerrpc.ResolveHoldForwardAction_RESUME,
 							OutgoingAmountMsat:      interceptResult.AmountMsat,
-							OutgoingRequestedChanId: uint64(interceptResult.ChannelId),
+							OutgoingRequestedChanId: uint64(interceptResult.Scid),
 							OnionBlob:               onion,
 						})
 					} else {
@@ -156,13 +165,13 @@ func (i *LndHtlcInterceptor) intercept() error {
 						})
 					}
 
-				case interceptor.INTERCEPT_FAIL_HTLC_WITH_CODE:
+				case shared.INTERCEPT_FAIL_HTLC_WITH_CODE:
 					interceptorClient.Send(&routerrpc.ForwardHtlcInterceptResponse{
 						IncomingCircuitKey: request.IncomingCircuitKey,
 						Action:             routerrpc.ResolveHoldForwardAction_FAIL,
 						FailureCode:        i.mapFailureCode(interceptResult.FailureCode),
 					})
-				case interceptor.INTERCEPT_RESUME:
+				case shared.INTERCEPT_RESUME:
 					fallthrough
 				default:
 					interceptorClient.Send(&routerrpc.ForwardHtlcInterceptResponse{
@@ -182,13 +191,13 @@ func (i *LndHtlcInterceptor) intercept() error {
 	}
 }
 
-func (i *LndHtlcInterceptor) mapFailureCode(original interceptor.InterceptFailureCode) lnrpc.Failure_FailureCode {
+func (i *LndHtlcInterceptor) mapFailureCode(original shared.InterceptFailureCode) lnrpc.Failure_FailureCode {
 	switch original {
-	case interceptor.FAILURE_TEMPORARY_CHANNEL_FAILURE:
+	case shared.FAILURE_TEMPORARY_CHANNEL_FAILURE:
 		return lnrpc.Failure_TEMPORARY_CHANNEL_FAILURE
-	case interceptor.FAILURE_TEMPORARY_NODE_FAILURE:
+	case shared.FAILURE_TEMPORARY_NODE_FAILURE:
 		return lnrpc.Failure_TEMPORARY_NODE_FAILURE
-	case interceptor.FAILURE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS:
+	case shared.FAILURE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS:
 		return lnrpc.Failure_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS
 	default:
 		log.Printf("Unknown failure code %v, default to temporary channel failure.", original)
@@ -197,7 +206,7 @@ func (i *LndHtlcInterceptor) mapFailureCode(original interceptor.InterceptFailur
 }
 
 func (i *LndHtlcInterceptor) constructOnion(
-	interceptResult interceptor.InterceptResult,
+	interceptResult shared.InterceptResult,
 	reqOutgoingExpiry uint32,
 	reqPaymentHash []byte,
 ) ([]byte, error) {

--- a/lsps0/time.go
+++ b/lsps0/time.go
@@ -1,3 +1,3 @@
-package basetypes
+package lsps0
 
 var TIME_FORMAT string = "2006-01-02T15:04:05.999Z"

--- a/lsps2/intercept_handler.go
+++ b/lsps2/intercept_handler.go
@@ -1,0 +1,674 @@
+package lsps2
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"log"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/breez/lspd/chain"
+	"github.com/breez/lspd/lightning"
+	"github.com/breez/lspd/lsps0"
+	"github.com/breez/lspd/shared"
+	"github.com/btcsuite/btcd/wire"
+)
+
+type InterceptorConfig struct {
+	AdditionalChannelCapacitySat uint64
+	MinConfs                     *uint32
+	TargetConf                   uint32
+	FeeStrategy                  chain.FeeStrategy
+	MinPaymentSizeMsat           uint64
+	MaxPaymentSizeMsat           uint64
+	TimeLockDelta                uint32
+	HtlcMinimumMsat              uint64
+	MppTimeout                   time.Duration
+}
+
+type Interceptor struct {
+	store               Lsps2Store
+	openingService      shared.OpeningService
+	client              lightning.Client
+	feeEstimator        chain.FeeEstimator
+	config              *InterceptorConfig
+	newPart             chan *partState
+	registrationFetched chan *registrationFetchedEvent
+	paymentReady        chan string
+	paymentFailure      chan *paymentFailureEvent
+	paymentChanOpened   chan *paymentChanOpenedEvent
+	inflightPayments    map[string]*paymentState
+}
+
+func NewInterceptHandler(
+	store Lsps2Store,
+	openingService shared.OpeningService,
+	client lightning.Client,
+	feeEstimator chain.FeeEstimator,
+	config *InterceptorConfig,
+) *Interceptor {
+	if config.MppTimeout.Nanoseconds() == 0 {
+		config.MppTimeout = time.Duration(90 * time.Second)
+	}
+
+	return &Interceptor{
+		store:          store,
+		openingService: openingService,
+		client:         client,
+		feeEstimator:   feeEstimator,
+		config:         config,
+		// TODO: make sure the chan sizes do not lead to deadlocks.
+		newPart:             make(chan *partState, 1000),
+		registrationFetched: make(chan *registrationFetchedEvent, 1000),
+		paymentReady:        make(chan string, 1000),
+		paymentFailure:      make(chan *paymentFailureEvent, 1000),
+		paymentChanOpened:   make(chan *paymentChanOpenedEvent, 1000),
+		inflightPayments:    make(map[string]*paymentState),
+	}
+}
+
+type paymentState struct {
+	id               string
+	fakeScid         lightning.ShortChannelID
+	outgoingSumMsat  uint64
+	paymentSizeMsat  uint64
+	feeMsat          uint64
+	registration     *BuyRegistration
+	parts            map[string]*partState
+	isFinal          bool
+	timoutChanClosed bool
+	timeoutChan      chan struct{}
+}
+
+func (p *paymentState) closeTimeoutChan() {
+	if p.timoutChanClosed {
+		return
+	}
+
+	close(p.timeoutChan)
+	p.timoutChanClosed = true
+}
+
+type partState struct {
+	req        *shared.InterceptRequest
+	resolution chan *shared.InterceptResult
+}
+
+type registrationFetchedEvent struct {
+	paymentId    string
+	isRegistered bool
+	registration *BuyRegistration
+}
+
+type paymentChanOpenedEvent struct {
+	paymentId       string
+	scid            lightning.ShortChannelID
+	channelPoint    *wire.OutPoint
+	htlcMinimumMsat uint64
+}
+
+type paymentFailureEvent struct {
+	paymentId string
+	code      shared.InterceptFailureCode
+}
+
+func (i *Interceptor) Start(ctx context.Context) {
+	// Main event loop for stages of htlcs to be handled. Note that the event
+	// loop has to execute quickly, so any code running in the 'handle' methods
+	// must execute quickly. If there is i/o involved, or any waiting, run that
+	// code in a goroutine, and place an event onto the event loop to continue
+	// processing after the slow operation is done.
+	// The nice thing about an event loop is that it runs on a single thread.
+	// So there's no locking needed, as long as everything that needs
+	// synchronization goes through the event loop.
+	for {
+		select {
+		case part := <-i.newPart:
+			i.handleNewPart(part)
+		case ev := <-i.registrationFetched:
+			i.handleRegistrationFetched(ev)
+		case paymentId := <-i.paymentReady:
+			i.handlePaymentReady(paymentId)
+		case ev := <-i.paymentFailure:
+			i.handlePaymentFailure(ev.paymentId, ev.code)
+		case ev := <-i.paymentChanOpened:
+			i.handlePaymentChanOpened(ev)
+		}
+	}
+}
+
+func (i *Interceptor) handleNewPart(part *partState) {
+	// Get the associated payment for this part, or create a new payment if it
+	// doesn't exist for this part yet.
+	paymentId := part.req.PaymentId()
+	payment, paymentExisted := i.inflightPayments[paymentId]
+	if !paymentExisted {
+		payment = &paymentState{
+			id:          paymentId,
+			fakeScid:    part.req.Scid,
+			parts:       make(map[string]*partState),
+			timeoutChan: make(chan struct{}),
+		}
+		i.inflightPayments[paymentId] = payment
+	}
+
+	// Check whether we already have this part, because it may have been
+	// replayed.
+	existingPart, partExisted := payment.parts[part.req.HtlcId()]
+	// Adds the part to the in-progress parts. Or replaces it, if it already
+	// exists, to make sure we always reply to the correct identifier. If a htlc
+	// was replayed, assume the latest event is the truth to respond to.
+	payment.parts[part.req.HtlcId()] = part
+
+	if partExisted {
+		// If the part already existed, that means it has been replayed. In this
+		// case the first occurence can be safely ignored, because we won't be
+		// able to reply to that htlc anyway. Keep the last replayed version for
+		// further processing. This result below tells the caller to ignore the
+		// htlc.
+		existingPart.resolution <- &shared.InterceptResult{
+			Action: shared.INTERCEPT_IGNORE,
+		}
+
+		return
+	}
+
+	// If this is the first part for this payment, setup the timeout, and fetch
+	// the registration.
+	if !paymentExisted {
+		go func() {
+			select {
+			case <-time.After(i.config.MppTimeout):
+				// Handle timeout inside the event loop, to make sure there are
+				// no race conditions, since this timeout watcher is running in
+				// a goroutine.
+				i.paymentFailure <- &paymentFailureEvent{
+					paymentId: paymentId,
+					code:      shared.FAILURE_TEMPORARY_CHANNEL_FAILURE,
+				}
+			case <-payment.timeoutChan:
+				// Stop listening for timeouts when the payment is ready.
+			}
+		}()
+
+		// Fetch the buy registration in a goroutine, to avoid blocking the
+		// event loop.
+		go i.fetchRegistration(part.req.PaymentId(), part.req.Scid)
+	}
+
+	// If the registration was already fetched, this part might complete the
+	// payment. Process the part. Otherwise, the part will be processed after
+	// the registration was fetched, as a result of 'registrationFetched'.
+	if payment.registration != nil {
+		i.processPart(payment, part)
+	}
+}
+
+func (i *Interceptor) processPart(payment *paymentState, part *partState) {
+	if payment.registration.IsComplete {
+		i.failPart(payment, part, shared.FAILURE_UNKNOWN_NEXT_PEER)
+		return
+	}
+
+	// Fail parts that come in after the payment is already final. To avoid
+	// inconsistencies in the payment state.
+	if payment.isFinal {
+		i.failPart(payment, part, shared.FAILURE_UNKNOWN_NEXT_PEER)
+		return
+	}
+
+	var err error
+	if payment.registration.Mode == OpeningMode_NoMppVarInvoice {
+		// Mode == no-MPP+var-invoice
+		if payment.paymentSizeMsat != 0 {
+			// Another part is already processed for this payment, and with
+			// no-MPP+var-invoice there can be only a single part, so this
+			// part will be failed back.
+			i.failPart(payment, part, shared.FAILURE_UNKNOWN_NEXT_PEER)
+			return
+		}
+
+		// If the mode is no-MPP+var-invoice, the payment size comes from
+		// the actual forwarded amount.
+		payment.paymentSizeMsat = part.req.OutgoingAmountMsat
+
+		// Make sure the minimum and maximum are not exceeded.
+		if payment.paymentSizeMsat > i.config.MaxPaymentSizeMsat ||
+			payment.paymentSizeMsat < i.config.MinPaymentSizeMsat {
+			i.failPart(payment, part, shared.FAILURE_UNKNOWN_NEXT_PEER)
+			return
+		}
+
+		// Make sure there is enough fee to deduct.
+		payment.feeMsat, err = computeOpeningFee(
+			payment.paymentSizeMsat,
+			payment.registration.OpeningFeeParams.Proportional,
+			payment.registration.OpeningFeeParams.MinFeeMsat,
+		)
+		if err != nil {
+			i.failPart(payment, part, shared.FAILURE_UNKNOWN_NEXT_PEER)
+			return
+		}
+
+		// Make sure the part fits the htlc and fee constraints.
+		if payment.feeMsat+i.config.HtlcMinimumMsat >
+			payment.paymentSizeMsat {
+			i.failPart(payment, part, shared.FAILURE_UNKNOWN_NEXT_PEER)
+			return
+		}
+	} else {
+		// Mode == MPP+fixed-invoice
+		payment.paymentSizeMsat = *payment.registration.PaymentSizeMsat
+		payment.feeMsat, err = computeOpeningFee(
+			payment.paymentSizeMsat,
+			payment.registration.OpeningFeeParams.Proportional,
+			payment.registration.OpeningFeeParams.MinFeeMsat,
+		)
+		if err != nil {
+			log.Printf(
+				"Opening fee calculation error while trying to open channel "+
+					"for scid %s: %v",
+				payment.registration.Scid.ToString(),
+				err,
+			)
+			i.failPart(payment, part, shared.FAILURE_UNKNOWN_NEXT_PEER)
+			return
+		}
+	}
+
+	// Make sure the cltv delta is enough (actual cltv delta + 2).
+	if int64(part.req.IncomingExpiry)-int64(part.req.OutgoingExpiry) <
+		int64(i.config.TimeLockDelta)+2 {
+		i.failPart(payment, part, shared.FAILURE_INCORRECT_CLTV_EXPIRY)
+		return
+	}
+
+	// Make sure htlc minimum is enough
+	if part.req.OutgoingAmountMsat < i.config.HtlcMinimumMsat {
+		i.failPart(payment, part, shared.FAILURE_AMOUNT_BELOW_MINIMUM)
+		return
+	}
+
+	// Make sure we're not getting tricked
+	if part.req.IncomingAmountMsat < part.req.OutgoingAmountMsat {
+		i.failPart(payment, part, shared.FAILURE_AMOUNT_BELOW_MINIMUM)
+		return
+	}
+
+	// Update the sum of htlcs currently in-flight.
+	payment.outgoingSumMsat += part.req.OutgoingAmountMsat
+
+	// If payment_size_msat is reached, the payment is ready to forward. (this
+	// is always true in no-MPP+var-invoice mode)
+	if payment.outgoingSumMsat >= payment.paymentSizeMsat {
+		payment.isFinal = true
+		i.paymentReady <- part.req.PaymentId()
+	}
+}
+
+// Fetches the registration from the store. If the registration exists, posts
+// a registrationReady event. If it doesn't, posts a 'notRegistered' event.
+func (i *Interceptor) fetchRegistration(
+	paymentId string,
+	scid lightning.ShortChannelID,
+) {
+	registration, err := i.store.GetBuyRegistration(
+		context.TODO(),
+		scid,
+	)
+
+	if err != nil && err != ErrNotFound {
+		log.Printf(
+			"Failed to get buy registration for %v: %v",
+			uint64(scid),
+			err,
+		)
+	}
+
+	i.registrationFetched <- &registrationFetchedEvent{
+		paymentId:    paymentId,
+		isRegistered: err == nil,
+		registration: registration,
+	}
+}
+
+func (i *Interceptor) handleRegistrationFetched(ev *registrationFetchedEvent) {
+	if !ev.isRegistered {
+		i.finalizeAllParts(ev.paymentId, &shared.InterceptResult{
+			Action: shared.INTERCEPT_RESUME,
+		})
+		return
+	}
+
+	payment, ok := i.inflightPayments[ev.paymentId]
+	if !ok {
+		// Apparently the payment is already finished.
+		return
+	}
+
+	payment.registration = ev.registration
+	for _, part := range payment.parts {
+		i.processPart(payment, part)
+	}
+}
+
+func (i *Interceptor) handlePaymentReady(paymentId string) {
+	payment, ok := i.inflightPayments[paymentId]
+	if !ok {
+		// Apparently this payment is already finalized.
+		return
+	}
+
+	// TODO: Handle notifications.
+	// Stops the timeout listeners
+	payment.closeTimeoutChan()
+
+	go i.ensureChannelOpen(payment)
+}
+
+// Opens a channel to the destination and waits for the channel to become
+// active. When the channel is active, sends an openChanEvent. Should be run in
+// a goroutine.
+func (i *Interceptor) ensureChannelOpen(payment *paymentState) {
+	destination, _ := hex.DecodeString(payment.registration.PeerId)
+
+	if payment.registration.ChannelPoint == nil {
+
+		validUntil, err := time.Parse(
+			lsps0.TIME_FORMAT,
+			payment.registration.OpeningFeeParams.ValidUntil,
+		)
+		if err != nil {
+			log.Printf(
+				"Failed parse validUntil '%s' for paymentId %s: %v",
+				payment.registration.OpeningFeeParams.ValidUntil,
+				payment.id,
+				err,
+			)
+			i.paymentFailure <- &paymentFailureEvent{
+				paymentId: payment.id,
+				code:      shared.FAILURE_UNKNOWN_NEXT_PEER,
+			}
+			return
+		}
+
+		// With expired fee params, the current chainfees are checked. If
+		// they're not cheaper now, fail the payment.
+		if time.Now().After(validUntil) &&
+			!i.openingService.IsCurrentChainFeeCheaper(
+				payment.registration.Token,
+				&payment.registration.OpeningFeeParams,
+			) {
+			log.Printf("LSPS2: Intercepted expired payment registration. "+
+				"Failing payment. scid: %s, valid until: %s, destination: %s",
+				payment.fakeScid.ToString(),
+				payment.registration.OpeningFeeParams.ValidUntil,
+				payment.registration.PeerId,
+			)
+			i.paymentFailure <- &paymentFailureEvent{
+				paymentId: payment.id,
+				code:      shared.FAILURE_UNKNOWN_NEXT_PEER,
+			}
+			return
+		}
+
+		var targetConf *uint32
+		confStr := "<nil>"
+		var feeEstimation *float64
+		feeStr := "<nil>"
+		if i.feeEstimator != nil {
+			fee, err := i.feeEstimator.EstimateFeeRate(
+				context.Background(),
+				i.config.FeeStrategy,
+			)
+			if err == nil {
+				feeEstimation = &fee.SatPerVByte
+				feeStr = fmt.Sprintf("%.5f", *feeEstimation)
+			} else {
+				log.Printf("Error estimating chain fee, fallback to target "+
+					"conf: %v", err)
+				targetConf = &i.config.TargetConf
+				confStr = fmt.Sprintf("%v", *targetConf)
+			}
+		}
+
+		capacity := ((payment.paymentSizeMsat - payment.feeMsat +
+			999) / 1000) + i.config.AdditionalChannelCapacitySat
+
+		log.Printf(
+			"LSPS2: Opening zero conf channel. Destination: %x, capacity: %v, "+
+				"fee: %s, targetConf: %s",
+			destination,
+			capacity,
+			feeStr,
+			confStr,
+		)
+
+		channelPoint, err := i.client.OpenChannel(&lightning.OpenChannelRequest{
+			Destination:    destination,
+			CapacitySat:    uint64(capacity),
+			MinConfs:       i.config.MinConfs,
+			IsPrivate:      true,
+			IsZeroConf:     true,
+			FeeSatPerVByte: feeEstimation,
+			TargetConf:     targetConf,
+		})
+		if err != nil {
+			log.Printf(
+				"LSPS2 openChannel: client.OpenChannel(%x, %v) error: %v",
+				destination,
+				capacity,
+				err,
+			)
+
+			code := shared.FAILURE_UNKNOWN_NEXT_PEER
+			if strings.Contains(err.Error(), "not enough funds") {
+				code = shared.FAILURE_TEMPORARY_CHANNEL_FAILURE
+			}
+
+			// TODO: Verify that a client disconnect before receiving
+			// funding_signed doesn't cause the OpenChannel call to error.
+			// unknown_next_peer should only be returned if the client rejects
+			// the channel, or the channel cannot be opened at all. If the
+			// client disconnects before receiving funding_signed,
+			// temporary_channel_failure should be returned.
+			i.paymentFailure <- &paymentFailureEvent{
+				paymentId: payment.id,
+				code:      code,
+			}
+			return
+		}
+
+		err = i.store.SetChannelOpened(
+			context.TODO(),
+			&ChannelOpened{
+				RegistrationId:  payment.registration.Id,
+				Outpoint:        channelPoint,
+				FeeMsat:         payment.feeMsat,
+				PaymentSizeMsat: payment.paymentSizeMsat,
+			},
+		)
+		if err != nil {
+			log.Printf(
+				"LSPS2 openChannel: store.SetOpenedChannel(%d, %s) error: %v",
+				payment.registration.Id,
+				channelPoint.String(),
+				err,
+			)
+			i.paymentFailure <- &paymentFailureEvent{
+				paymentId: payment.id,
+				code:      shared.FAILURE_TEMPORARY_CHANNEL_FAILURE,
+			}
+			return
+		}
+
+		payment.registration.ChannelPoint = channelPoint
+		// TODO: Send open channel email notification.
+	}
+	deadline := time.Now().Add(time.Minute)
+	// Wait for the channel to open.
+	for {
+		chanResult, _ := i.client.GetChannel(
+			destination,
+			*payment.registration.ChannelPoint,
+		)
+		if chanResult == nil {
+			select {
+			case <-time.After(time.Second):
+				continue
+			case <-time.After(time.Until(deadline)):
+				i.paymentFailure <- &paymentFailureEvent{
+					paymentId: payment.id,
+					code:      shared.FAILURE_TEMPORARY_CHANNEL_FAILURE,
+				}
+				return
+			}
+		}
+		log.Printf(
+			"Got new channel for forward successfully. scid alias: %v, "+
+				"confirmed scid: %v",
+			chanResult.InitialChannelID.ToString(),
+			chanResult.ConfirmedChannelID.ToString(),
+		)
+
+		scid := chanResult.ConfirmedChannelID
+		if uint64(scid) == 0 {
+			scid = chanResult.InitialChannelID
+		}
+
+		i.paymentChanOpened <- &paymentChanOpenedEvent{
+			paymentId:       payment.id,
+			scid:            scid,
+			channelPoint:    payment.registration.ChannelPoint,
+			htlcMinimumMsat: chanResult.HtlcMinimumMsat,
+		}
+		break
+	}
+}
+
+func (i *Interceptor) handlePaymentChanOpened(event *paymentChanOpenedEvent) {
+	payment, ok := i.inflightPayments[event.paymentId]
+	if !ok {
+		// Apparently this payment is already finalized.
+		return
+	}
+	feeRemainingMsat := payment.feeMsat
+
+	destination, _ := hex.DecodeString(payment.registration.PeerId)
+	// Deduct the lsp fee from the parts to forward.
+	resolutions := []*struct {
+		part       *partState
+		resolution *shared.InterceptResult
+	}{}
+	for _, part := range payment.parts {
+		deductMsat := uint64(math.Min(
+			float64(feeRemainingMsat),
+			float64(part.req.OutgoingAmountMsat-event.htlcMinimumMsat),
+		))
+		feeRemainingMsat -= deductMsat
+		amountMsat := part.req.OutgoingAmountMsat - deductMsat
+		var feeMsat *uint64
+		if deductMsat > 0 {
+			feeMsat = &deductMsat
+		}
+		resolutions = append(resolutions, &struct {
+			part       *partState
+			resolution *shared.InterceptResult
+		}{
+			part: part,
+			resolution: &shared.InterceptResult{
+				Action:       shared.INTERCEPT_RESUME_WITH_ONION,
+				Destination:  destination,
+				ChannelPoint: event.channelPoint,
+				AmountMsat:   amountMsat,
+				FeeMsat:      feeMsat,
+				Scid:         event.scid,
+			},
+		})
+	}
+
+	if feeRemainingMsat > 0 {
+		// It is possible this case happens if the htlc_minimum_msat is larger
+		// than 1. We might not be able to deduct the opening fees from the
+		// payment entirely. This is an edge case, and we'll fail the payment.
+		log.Printf(
+			"After deducting fees from payment parts, there was still fee "+
+				"remaining. payment id: %s, fee remaining msat: %d. Failing "+
+				"payment.",
+			event.paymentId,
+			feeRemainingMsat,
+		)
+		// TODO: Verify temporary_channel_failure is the way to go here, maybe
+		// unknown_next_peer is more appropriate.
+		i.paymentFailure <- &paymentFailureEvent{
+			paymentId: event.paymentId,
+			code:      shared.FAILURE_TEMPORARY_CHANNEL_FAILURE,
+		}
+		return
+	}
+
+	for _, resolution := range resolutions {
+		resolution.part.resolution <- resolution.resolution
+	}
+
+	payment.registration.IsComplete = true
+	go i.store.SetCompleted(context.TODO(), payment.registration.Id)
+	delete(i.inflightPayments, event.paymentId)
+}
+
+func (i *Interceptor) handlePaymentFailure(
+	paymentId string,
+	code shared.InterceptFailureCode,
+) {
+	i.finalizeAllParts(paymentId, &shared.InterceptResult{
+		Action:      shared.INTERCEPT_FAIL_HTLC_WITH_CODE,
+		FailureCode: code,
+	})
+}
+
+func (i *Interceptor) finalizeAllParts(
+	paymentId string,
+	result *shared.InterceptResult,
+) {
+	payment, ok := i.inflightPayments[paymentId]
+	if !ok {
+		// Apparently this payment is already finalized.
+		return
+	}
+
+	// Stops the timeout listeners
+	payment.closeTimeoutChan()
+
+	for _, part := range payment.parts {
+		part.resolution <- result
+	}
+	delete(i.inflightPayments, paymentId)
+}
+
+func (i *Interceptor) Intercept(req shared.InterceptRequest) shared.InterceptResult {
+	resolution := make(chan *shared.InterceptResult, 1)
+	i.newPart <- &partState{
+		req:        &req,
+		resolution: resolution,
+	}
+	res := <-resolution
+	return *res
+}
+
+func (i *Interceptor) failPart(
+	payment *paymentState,
+	part *partState,
+	code shared.InterceptFailureCode,
+) {
+	part.resolution <- &shared.InterceptResult{
+		Action:      shared.INTERCEPT_FAIL_HTLC_WITH_CODE,
+		FailureCode: code,
+	}
+	delete(payment.parts, part.req.HtlcId())
+	if len(payment.parts) == 0 {
+		payment.closeTimeoutChan()
+		delete(i.inflightPayments, part.req.PaymentId())
+	}
+}

--- a/lsps2/intercept_test.go
+++ b/lsps2/intercept_test.go
@@ -1,0 +1,758 @@
+package lsps2
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/breez/lspd/chain"
+	"github.com/breez/lspd/lightning"
+	"github.com/breez/lspd/lsps0"
+	"github.com/breez/lspd/shared"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/stretchr/testify/assert"
+)
+
+var defaultScid uint64 = 123
+var defaultPaymentSizeMsat uint64 = 1_000_000
+var defaultMinViableAmount uint64 = defaultOpeningFeeParams().MinFeeMsat + defaultConfig().HtlcMinimumMsat
+var defaultFee, _ = computeOpeningFee(
+	defaultPaymentSizeMsat,
+	defaultOpeningFeeParams().Proportional,
+	defaultOpeningFeeParams().MinFeeMsat,
+)
+var defaultChainHash = chainhash.Hash([32]byte{})
+var defaultOutPoint = wire.NewOutPoint(&defaultChainHash, 0)
+var defaultChannelScid uint64 = 456
+var defaultChanResult = &lightning.GetChannelResult{
+	HtlcMinimumMsat:    defaultConfig().HtlcMinimumMsat,
+	InitialChannelID:   lightning.ShortChannelID(defaultChannelScid),
+	ConfirmedChannelID: lightning.ShortChannelID(defaultChannelScid),
+}
+
+func defaultOpeningFeeParams() shared.OpeningFeeParams {
+	return shared.OpeningFeeParams{
+		MinFeeMsat:           1000,
+		Proportional:         1000,
+		ValidUntil:           time.Now().UTC().Add(5 * time.Hour).Format(lsps0.TIME_FORMAT),
+		MinLifetime:          1000,
+		MaxClientToSelfDelay: 2016,
+		Promise:              "fake",
+	}
+}
+func defaultStore() *mockLsps2Store {
+	return &mockLsps2Store{
+		registrations: map[uint64]*BuyRegistration{
+			defaultScid: {
+				PeerId:           "peer",
+				Scid:             lightning.ShortChannelID(defaultScid),
+				Mode:             OpeningMode_NoMppVarInvoice,
+				OpeningFeeParams: defaultOpeningFeeParams(),
+			},
+		},
+	}
+}
+
+func mppStore() *mockLsps2Store {
+	s := defaultStore()
+	for _, r := range s.registrations {
+		r.Mode = OpeningMode_MppFixedInvoice
+		r.PaymentSizeMsat = &defaultPaymentSizeMsat
+	}
+	return s
+}
+
+func defaultClient() *mockLightningClient {
+	return &mockLightningClient{
+		openResponses: []*wire.OutPoint{
+			defaultOutPoint,
+		},
+		getChanResponses: []*lightning.GetChannelResult{
+			defaultChanResult,
+		},
+	}
+}
+
+func defaultFeeEstimator() *mockFeeEstimator {
+	return nil
+}
+
+func defaultopeningService() *mockOpeningService {
+	return &mockOpeningService{
+		isCurrentChainFeeCheaper: false,
+	}
+}
+
+func defaultConfig() *InterceptorConfig {
+	var minConfs uint32 = 1
+	return &InterceptorConfig{
+		AdditionalChannelCapacitySat: 100_000,
+		MinConfs:                     &minConfs,
+		TargetConf:                   6,
+		FeeStrategy:                  chain.FeeStrategyEconomy,
+		MinPaymentSizeMsat:           1_000,
+		MaxPaymentSizeMsat:           4_000_000_000,
+		TimeLockDelta:                144,
+		HtlcMinimumMsat:              100,
+	}
+}
+
+type interceptP struct {
+	store          *mockLsps2Store
+	openingService *mockOpeningService
+	client         *mockLightningClient
+	feeEstimator   *mockFeeEstimator
+	config         *InterceptorConfig
+}
+
+func setupInterceptor(
+	ctx context.Context,
+	p *interceptP,
+) *Interceptor {
+	var store *mockLsps2Store
+	if p != nil && p.store != nil {
+		store = p.store
+	} else {
+		store = defaultStore()
+	}
+
+	var client *mockLightningClient
+	if p != nil && p.client != nil {
+		client = p.client
+	} else {
+		client = defaultClient()
+	}
+
+	var f *mockFeeEstimator
+	if p != nil && p.feeEstimator != nil {
+		f = p.feeEstimator
+	} else {
+		f = defaultFeeEstimator()
+	}
+
+	var config *InterceptorConfig
+	if p != nil && p.config != nil {
+		config = p.config
+	} else {
+		config = defaultConfig()
+	}
+
+	var openingService *mockOpeningService
+	if p != nil && p.openingService != nil {
+		openingService = p.openingService
+	} else {
+		openingService = defaultopeningService()
+	}
+
+	i := NewInterceptHandler(store, openingService, client, f, config)
+	go i.Start(ctx)
+	return i
+}
+
+type part struct {
+	id        string
+	scid      uint64
+	ph        []byte
+	amt       uint64
+	cltvDelta uint32
+}
+
+func createPart(p *part) shared.InterceptRequest {
+	id := "first"
+	if p != nil && p.id != "" {
+		id = p.id
+	}
+
+	scid := lightning.ShortChannelID(defaultScid)
+	if p != nil && p.scid != 0 {
+		scid = lightning.ShortChannelID(p.scid)
+	}
+
+	ph := []byte("fake payment hash")
+	if p != nil && p.ph != nil && len(p.ph) > 0 {
+		ph = p.ph
+	}
+
+	var amt uint64 = 1_000_000
+	if p != nil && p.amt != 0 {
+		amt = p.amt
+	}
+
+	var cltv uint32 = 146
+	if p != nil && p.cltvDelta != 0 {
+		cltv = p.cltvDelta
+	}
+
+	return shared.InterceptRequest{
+		Identifier:         id,
+		Scid:               scid,
+		PaymentHash:        ph,
+		IncomingAmountMsat: amt,
+		OutgoingAmountMsat: amt,
+		IncomingExpiry:     100 + cltv,
+		OutgoingExpiry:     100,
+	}
+}
+
+func runIntercept(i *Interceptor, req shared.InterceptRequest, res *shared.InterceptResult, wg *sync.WaitGroup) {
+	go func() {
+		*res = i.Intercept(req)
+		wg.Done()
+	}()
+}
+
+func assertEmpty(t *testing.T, i *Interceptor) {
+	assert.Empty(t, i.inflightPayments)
+	assert.Empty(t, i.newPart)
+	assert.Empty(t, i.registrationFetched)
+	assert.Empty(t, i.paymentChanOpened)
+	assert.Empty(t, i.paymentFailure)
+	assert.Empty(t, i.paymentReady)
+}
+
+// Asserts that a part that is not associated with a bought channel is not
+// handled by the interceptor. This allows the legacy interceptor to pick up
+// from there.
+func Test_NotBought_SinglePart(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	i := setupInterceptor(ctx, nil)
+	res := i.Intercept(createPart(&part{scid: 999}))
+	assert.Equal(t, shared.INTERCEPT_RESUME, res.Action)
+	assertEmpty(t, i)
+}
+
+func Test_NotBought_TwoParts(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	i := setupInterceptor(ctx, nil)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	var res1 shared.InterceptResult
+	runIntercept(i, createPart(&part{id: "first", scid: 999}), &res1, &wg)
+
+	var res2 shared.InterceptResult
+	runIntercept(i, createPart(&part{id: "second", scid: 999}), &res2, &wg)
+	wg.Wait()
+	assert.Equal(t, shared.INTERCEPT_RESUME, res1.Action)
+	assert.Equal(t, shared.INTERCEPT_RESUME, res2.Action)
+	assertEmpty(t, i)
+}
+
+// Asserts that a no-MPP+var-invoice mode payment works in the happy flow.
+func Test_NoMpp_Happyflow(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	i := setupInterceptor(ctx, nil)
+
+	res := i.Intercept(createPart(nil))
+	assert.Equal(t, shared.INTERCEPT_RESUME_WITH_ONION, res.Action)
+	assert.Equal(t, defaultPaymentSizeMsat-defaultFee, res.AmountMsat)
+	assert.Equal(t, defaultFee, *res.FeeMsat)
+	assert.Equal(t, defaultChannelScid, uint64(res.Scid))
+	assertEmpty(t, i)
+}
+
+// Asserts that a no-MPP+var-invoice mode payment works with the exact minimum
+// amount.
+func Test_NoMpp_AmountMinFeePlusHtlcMinPlusOne(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	i := setupInterceptor(ctx, nil)
+
+	res := i.Intercept(createPart(&part{amt: defaultMinViableAmount}))
+	assert.Equal(t, shared.INTERCEPT_RESUME_WITH_ONION, res.Action)
+	assert.Equal(t, defaultConfig().HtlcMinimumMsat, res.AmountMsat)
+	assert.Equal(t, defaultOpeningFeeParams().MinFeeMsat, *res.FeeMsat)
+	assert.Equal(t, defaultChannelScid, uint64(res.Scid))
+	assertEmpty(t, i)
+}
+
+// Asserts that a no-MPP+var-invoice mode payment fails with the exact minimum
+// amount minus one.
+func Test_NoMpp_AmtBelowMinimum(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	i := setupInterceptor(ctx, nil)
+
+	res := i.Intercept(createPart(&part{amt: defaultMinViableAmount - 1}))
+	assert.Equal(t, shared.INTERCEPT_FAIL_HTLC_WITH_CODE, res.Action)
+	assert.Equal(t, shared.FAILURE_UNKNOWN_NEXT_PEER, res.FailureCode)
+	assertEmpty(t, i)
+}
+
+// Asserts that a no-MPP+var-invoice mode payment succeeds with the exact
+// maximum amount.
+func Test_NoMpp_AmtAtMaximum(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	i := setupInterceptor(ctx, nil)
+
+	res := i.Intercept(createPart(&part{amt: defaultConfig().MaxPaymentSizeMsat}))
+	assert.Equal(t, shared.INTERCEPT_RESUME_WITH_ONION, res.Action)
+	assertEmpty(t, i)
+}
+
+// Asserts that a no-MPP+var-invoice mode payment fails with the exact
+// maximum amount plus one.
+func Test_NoMpp_AmtAboveMaximum(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	i := setupInterceptor(ctx, nil)
+
+	res := i.Intercept(createPart(&part{amt: defaultConfig().MaxPaymentSizeMsat + 1}))
+	assert.Equal(t, shared.INTERCEPT_FAIL_HTLC_WITH_CODE, res.Action)
+	assert.Equal(t, shared.FAILURE_UNKNOWN_NEXT_PEER, res.FailureCode)
+	assertEmpty(t, i)
+}
+
+// Asserts that a no-MPP+var-invoice mode payment fails when the cltv delta is
+// less than cltv delta + 2.
+func Test_NoMpp_CltvDeltaBelowMinimum(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	i := setupInterceptor(ctx, nil)
+
+	res := i.Intercept(createPart(&part{cltvDelta: 145}))
+	assert.Equal(t, shared.INTERCEPT_FAIL_HTLC_WITH_CODE, res.Action)
+	assert.Equal(t, shared.FAILURE_INCORRECT_CLTV_EXPIRY, res.FailureCode)
+	assertEmpty(t, i)
+}
+
+// Asserts that a no-MPP+var-invoice mode payment succeeds when the cltv delta
+// is higher than expected.
+func Test_NoMpp_HigherCltvDelta(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	i := setupInterceptor(ctx, nil)
+
+	res := i.Intercept(createPart(&part{cltvDelta: 1000}))
+	assert.Equal(t, shared.INTERCEPT_RESUME_WITH_ONION, res.Action)
+	assertEmpty(t, i)
+}
+
+// Asserts that a no-MPP+var-invoice mode payment fails if the opening params
+// have expired.
+func Test_NoMpp_ParamsExpired(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	store := defaultStore()
+	store.registrations[defaultScid].OpeningFeeParams.ValidUntil = time.Now().
+		UTC().Add(-time.Nanosecond).Format(lsps0.TIME_FORMAT)
+	i := setupInterceptor(ctx, &interceptP{store: store})
+
+	res := i.Intercept(createPart(nil))
+	assert.Equal(t, shared.INTERCEPT_FAIL_HTLC_WITH_CODE, res.Action)
+	assert.Equal(t, shared.FAILURE_UNKNOWN_NEXT_PEER, res.FailureCode)
+	assertEmpty(t, i)
+}
+
+func Test_NoMpp_ChannelAlreadyOpened_NotComplete_Forwards(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	store := defaultStore()
+	store.registrations[defaultScid].ChannelPoint = defaultOutPoint
+	i := setupInterceptor(ctx, &interceptP{store: store})
+
+	res := i.Intercept(createPart(nil))
+	assert.Equal(t, shared.INTERCEPT_RESUME_WITH_ONION, res.Action)
+	assertEmpty(t, i)
+}
+
+func Test_NoMpp_ChannelAlreadyOpened_Complete_Fails(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	store := defaultStore()
+	store.registrations[defaultScid].ChannelPoint = defaultOutPoint
+	store.registrations[defaultScid].IsComplete = true
+	i := setupInterceptor(ctx, &interceptP{store: store})
+
+	res := i.Intercept(createPart(nil))
+	assert.Equal(t, shared.INTERCEPT_FAIL_HTLC_WITH_CODE, res.Action)
+	assert.Equal(t, shared.FAILURE_UNKNOWN_NEXT_PEER, res.FailureCode)
+	assertEmpty(t, i)
+}
+
+// Asserts that a MPP+fixed-invoice mode payment succeeds in the happy flow
+// case.
+func Test_Mpp_SinglePart_Happyflow(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	i := setupInterceptor(ctx, &interceptP{store: mppStore()})
+
+	res := i.Intercept(createPart(&part{amt: defaultPaymentSizeMsat}))
+	assert.Equal(t, shared.INTERCEPT_RESUME_WITH_ONION, res.Action)
+	assert.Equal(t, defaultPaymentSizeMsat-defaultFee, res.AmountMsat)
+	assert.Equal(t, defaultFee, *res.FeeMsat)
+	assert.Equal(t, defaultChannelScid, uint64(res.Scid))
+	assertEmpty(t, i)
+}
+
+// Asserts that a MPP+fixed-invoice mode payment times out when it receives only
+// a single part below payment_size_msat.
+func Test_Mpp_SinglePart_AmtTooSmall(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	config := defaultConfig()
+	config.MppTimeout = time.Millisecond * 500
+	i := setupInterceptor(ctx, &interceptP{store: mppStore(), config: config})
+
+	start := time.Now()
+	res := i.Intercept(createPart(&part{amt: defaultPaymentSizeMsat - 1}))
+	end := time.Now()
+	assert.Equal(t, shared.INTERCEPT_FAIL_HTLC_WITH_CODE, res.Action)
+	assert.Equal(t, shared.FAILURE_TEMPORARY_CHANNEL_FAILURE, res.FailureCode)
+	assert.GreaterOrEqual(t, end.Sub(start).Milliseconds(), config.MppTimeout.Milliseconds())
+	assertEmpty(t, i)
+}
+
+// Asserts that a MPP+fixed-invoice mode payment finalizes after it receives the
+// second part that finalizes the payment.
+func Test_Mpp_TwoParts_FinalizedOnSecond(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	config := defaultConfig()
+	config.MppTimeout = time.Millisecond * 500
+	i := setupInterceptor(ctx, &interceptP{store: mppStore(), config: config})
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	var res1 shared.InterceptResult
+	var res2 shared.InterceptResult
+	var t1 time.Time
+	var t2 time.Time
+	start := time.Now()
+	go func() {
+		res1 = i.Intercept(createPart(&part{
+			id:  "first",
+			amt: defaultPaymentSizeMsat - defaultConfig().HtlcMinimumMsat,
+		}))
+		t1 = time.Now()
+		wg.Done()
+	}()
+
+	<-time.After(time.Millisecond * 250)
+
+	go func() {
+		res2 = i.Intercept(createPart(&part{
+			id:  "second",
+			amt: defaultConfig().HtlcMinimumMsat,
+		}))
+		t2 = time.Now()
+		wg.Done()
+	}()
+
+	wg.Wait()
+	assert.Equal(t, shared.INTERCEPT_RESUME_WITH_ONION, res1.Action)
+	assert.Equal(t, defaultPaymentSizeMsat-defaultConfig().HtlcMinimumMsat-defaultFee, res1.AmountMsat)
+	assert.Equal(t, defaultFee, *res1.FeeMsat)
+
+	assert.Equal(t, shared.INTERCEPT_RESUME_WITH_ONION, res2.Action)
+	assert.Equal(t, defaultConfig().HtlcMinimumMsat, res2.AmountMsat)
+	assert.Nil(t, res2.FeeMsat)
+
+	assert.LessOrEqual(t, int64(250), t1.Sub(start).Milliseconds())
+	assert.LessOrEqual(t, int64(250), t2.Sub(start).Milliseconds())
+	assertEmpty(t, i)
+}
+
+// Asserts that a MPP+fixed-invoice mode payment with the following parts
+// 1) payment size - htlc minimum
+// 2) htlc minimum - 1
+// 3) htlc minimum
+// still succeeds. The second part is dropped, but the third part completes the
+// payment.
+func Test_Mpp_BadSecondPart_ThirdPartCompletes(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	config := defaultConfig()
+	config.MppTimeout = time.Millisecond * 500
+	i := setupInterceptor(ctx, &interceptP{store: mppStore(), config: config})
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	var res1 shared.InterceptResult
+	var res2 shared.InterceptResult
+	var res3 shared.InterceptResult
+	var t1 time.Time
+	var t2 time.Time
+	var t3 time.Time
+	start := time.Now()
+	go func() {
+		res1 = i.Intercept(createPart(&part{
+			id:  "first",
+			amt: defaultPaymentSizeMsat - defaultConfig().HtlcMinimumMsat,
+		}))
+		t1 = time.Now()
+		wg.Done()
+	}()
+
+	<-time.After(time.Millisecond * 100)
+	res2 = i.Intercept(createPart(&part{
+		id:  "second",
+		amt: defaultConfig().HtlcMinimumMsat - 1,
+	}))
+	t2 = time.Now()
+
+	<-time.After(time.Millisecond * 100)
+	go func() {
+		res3 = i.Intercept(createPart(&part{
+			id:  "third",
+			amt: defaultConfig().HtlcMinimumMsat,
+		}))
+		t3 = time.Now()
+		wg.Done()
+	}()
+
+	wg.Wait()
+	assert.Equal(t, shared.INTERCEPT_RESUME_WITH_ONION, res1.Action)
+	assert.Equal(t, defaultPaymentSizeMsat-defaultConfig().HtlcMinimumMsat-defaultFee, res1.AmountMsat)
+	assert.Equal(t, defaultFee, *res1.FeeMsat)
+
+	assert.Equal(t, shared.INTERCEPT_FAIL_HTLC_WITH_CODE, res2.Action)
+	assert.Equal(t, shared.FAILURE_AMOUNT_BELOW_MINIMUM, res2.FailureCode)
+
+	assert.Equal(t, shared.INTERCEPT_RESUME_WITH_ONION, res3.Action)
+	assert.Equal(t, defaultConfig().HtlcMinimumMsat, res3.AmountMsat)
+	assert.Nil(t, res3.FeeMsat)
+
+	assert.LessOrEqual(t, int64(200), t1.Sub(start).Milliseconds())
+	assert.Greater(t, int64(200), t2.Sub(start).Milliseconds())
+	assert.LessOrEqual(t, int64(200), t3.Sub(start).Milliseconds())
+
+	assertEmpty(t, i)
+}
+
+// Asserts that a MPP+fixed-invoice mode payment fails when the cltv delta is
+// less than cltv delta + 2.
+func Test_Mpp_CltvDeltaBelowMinimum(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	i := setupInterceptor(ctx, &interceptP{store: mppStore()})
+
+	res := i.Intercept(createPart(&part{cltvDelta: 145}))
+	assert.Equal(t, shared.INTERCEPT_FAIL_HTLC_WITH_CODE, res.Action)
+	assert.Equal(t, shared.FAILURE_INCORRECT_CLTV_EXPIRY, res.FailureCode)
+	assertEmpty(t, i)
+}
+
+// Asserts that a MPP+fixed-invoice mode payment succeeds when the cltv delta
+// is higher than expected.
+func Test_Mpp_HigherCltvDelta(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	i := setupInterceptor(ctx, &interceptP{store: mppStore()})
+
+	res := i.Intercept(createPart(&part{cltvDelta: 1000}))
+	assert.Equal(t, shared.INTERCEPT_RESUME_WITH_ONION, res.Action)
+	assertEmpty(t, i)
+}
+
+// Asserts that a MPP+fixed-invoice mode payment fails if the opening params
+// have expired.
+func Test_Mpp_ParamsExpired(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	store := mppStore()
+	store.registrations[defaultScid].OpeningFeeParams.ValidUntil = time.Now().
+		UTC().Add(-time.Nanosecond).Format(lsps0.TIME_FORMAT)
+	i := setupInterceptor(ctx, &interceptP{store: store})
+
+	res := i.Intercept(createPart(nil))
+	assert.Equal(t, shared.INTERCEPT_FAIL_HTLC_WITH_CODE, res.Action)
+	assert.Equal(t, shared.FAILURE_UNKNOWN_NEXT_PEER, res.FailureCode)
+	assertEmpty(t, i)
+}
+
+// Asserts that a MPP+fixed-invoice mode payment fails if the opening params
+// expire while the part is in-flight.
+func Test_Mpp_ParamsExpireInFlight(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	store := mppStore()
+	i := setupInterceptor(ctx, &interceptP{store: store})
+
+	start := time.Now()
+	store.registrations[defaultScid].OpeningFeeParams.ValidUntil = start.
+		UTC().Add(time.Millisecond * 250).Format(lsps0.TIME_FORMAT)
+
+	var res1 shared.InterceptResult
+	var res2 shared.InterceptResult
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		res1 = i.Intercept(createPart(&part{
+			id:  "first",
+			amt: defaultPaymentSizeMsat - defaultConfig().HtlcMinimumMsat,
+		}))
+		wg.Done()
+	}()
+
+	<-time.After(time.Millisecond * 300)
+	res2 = i.Intercept(createPart(&part{
+		id:  "second",
+		amt: defaultConfig().HtlcMinimumMsat,
+	}))
+
+	wg.Wait()
+	assert.Equal(t, shared.INTERCEPT_FAIL_HTLC_WITH_CODE, res1.Action)
+	assert.Equal(t, shared.FAILURE_UNKNOWN_NEXT_PEER, res1.FailureCode)
+	assert.Equal(t, shared.INTERCEPT_FAIL_HTLC_WITH_CODE, res2.Action)
+	assert.Equal(t, shared.FAILURE_UNKNOWN_NEXT_PEER, res2.FailureCode)
+
+	assertEmpty(t, i)
+}
+
+// Asserts that a MPP+fixed-invoice mode replacement of a part ignores that
+// part, and the replacement is used for completing the payment
+func Test_Mpp_PartReplacement(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	i := setupInterceptor(ctx, &interceptP{store: mppStore()})
+
+	var wg sync.WaitGroup
+	wg.Add(3)
+	var res1 shared.InterceptResult
+	var res2 shared.InterceptResult
+	var res3 shared.InterceptResult
+	var t1 time.Time
+	var t2 time.Time
+	var t3 time.Time
+	start := time.Now()
+	go func() {
+		res1 = i.Intercept(createPart(&part{
+			id:  "first",
+			amt: defaultPaymentSizeMsat - defaultConfig().HtlcMinimumMsat,
+		}))
+		t1 = time.Now()
+		wg.Done()
+	}()
+
+	<-time.After(time.Millisecond * 100)
+	go func() {
+		res2 = i.Intercept(createPart(&part{
+			id:  "first",
+			amt: defaultPaymentSizeMsat - defaultConfig().HtlcMinimumMsat,
+		}))
+		t2 = time.Now()
+		wg.Done()
+	}()
+
+	<-time.After(time.Millisecond * 100)
+	go func() {
+		res3 = i.Intercept(createPart(&part{
+			id:  "second",
+			amt: defaultConfig().HtlcMinimumMsat,
+		}))
+		t3 = time.Now()
+		wg.Done()
+	}()
+
+	wg.Wait()
+	assert.Equal(t, shared.INTERCEPT_IGNORE, res1.Action)
+
+	assert.Equal(t, shared.INTERCEPT_RESUME_WITH_ONION, res2.Action)
+	assert.Equal(t, defaultPaymentSizeMsat-defaultConfig().HtlcMinimumMsat-defaultFee, res2.AmountMsat)
+	assert.Equal(t, defaultFee, *res2.FeeMsat)
+
+	assert.Equal(t, shared.INTERCEPT_RESUME_WITH_ONION, res3.Action)
+	assert.Equal(t, defaultConfig().HtlcMinimumMsat, res3.AmountMsat)
+	assert.Nil(t, res3.FeeMsat)
+
+	assert.LessOrEqual(t, int64(100), t1.Sub(start).Milliseconds())
+	assert.LessOrEqual(t, int64(200), t2.Sub(start).Milliseconds())
+	assert.LessOrEqual(t, int64(200), t3.Sub(start).Milliseconds())
+
+	assertEmpty(t, i)
+}
+
+func Test_Mpp_ChannelAlreadyOpened_NotComplete_Forwards(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	store := mppStore()
+	store.registrations[defaultScid].ChannelPoint = defaultOutPoint
+	i := setupInterceptor(ctx, &interceptP{store: store})
+
+	res := i.Intercept(createPart(nil))
+	assert.Equal(t, shared.INTERCEPT_RESUME_WITH_ONION, res.Action)
+	assertEmpty(t, i)
+}
+
+func Test_Mpp_ChannelAlreadyOpened_Complete_Fails(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	store := mppStore()
+	store.registrations[defaultScid].ChannelPoint = defaultOutPoint
+	store.registrations[defaultScid].IsComplete = true
+	i := setupInterceptor(ctx, &interceptP{store: store})
+
+	res := i.Intercept(createPart(nil))
+	assert.Equal(t, shared.INTERCEPT_FAIL_HTLC_WITH_CODE, res.Action)
+	assert.Equal(t, shared.FAILURE_UNKNOWN_NEXT_PEER, res.FailureCode)
+	assertEmpty(t, i)
+}
+
+func Test_Mpp_Performance(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	paymentCount := 100
+	partCount := 10
+	store := &mockLsps2Store{
+		delay:         time.Millisecond * 500,
+		registrations: make(map[uint64]*BuyRegistration),
+	}
+
+	client := &mockLightningClient{}
+	for paymentNo := 0; paymentNo < paymentCount; paymentNo++ {
+		scid := uint64(paymentNo + 1_000_000)
+		client.getChanResponses = append(client.getChanResponses, defaultChanResult)
+		client.openResponses = append(client.openResponses, defaultOutPoint)
+		store.registrations[scid] = &BuyRegistration{
+			PeerId:           strconv.FormatUint(scid, 10),
+			Scid:             lightning.ShortChannelID(scid),
+			Mode:             OpeningMode_MppFixedInvoice,
+			OpeningFeeParams: defaultOpeningFeeParams(),
+			PaymentSizeMsat:  &defaultPaymentSizeMsat,
+		}
+	}
+	i := setupInterceptor(ctx, &interceptP{store: store, client: client})
+	var wg sync.WaitGroup
+	wg.Add(partCount * paymentCount)
+	start := time.Now()
+	for paymentNo := 0; paymentNo < paymentCount; paymentNo++ {
+		for partNo := 0; partNo < partCount; partNo++ {
+			scid := paymentNo + 1_000_000
+			id := fmt.Sprintf("%d|%d", paymentNo, partNo)
+			var a [8]byte
+			binary.BigEndian.PutUint64(a[:], uint64(scid))
+			ph := sha256.Sum256(a[:])
+
+			go func() {
+				res := i.Intercept(createPart(&part{
+					scid: uint64(scid),
+					id:   id,
+					ph:   ph[:],
+					amt:  defaultPaymentSizeMsat / uint64(partCount),
+				}))
+
+				assert.Equal(t, shared.INTERCEPT_RESUME_WITH_ONION, res.Action)
+				wg.Done()
+			}()
+		}
+	}
+	wg.Wait()
+	end := time.Now()
+
+	assert.LessOrEqual(t, end.Sub(start).Milliseconds(), int64(1000))
+	assertEmpty(t, i)
+}

--- a/lsps2/mocks.go
+++ b/lsps2/mocks.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/breez/lspd/basetypes"
 	"github.com/breez/lspd/chain"
 	"github.com/breez/lspd/lightning"
 	"github.com/breez/lspd/shared"
@@ -61,7 +60,7 @@ func (s *mockLsps2Store) RegisterBuy(ctx context.Context, req *RegisterBuy) erro
 	return s.err
 }
 
-func (s *mockLsps2Store) GetBuyRegistration(ctx context.Context, scid basetypes.ShortChannelID) (*BuyRegistration, error) {
+func (s *mockLsps2Store) GetBuyRegistration(ctx context.Context, scid lightning.ShortChannelID) (*BuyRegistration, error) {
 	if s.delay.Nanoseconds() != 0 {
 		<-time.After(s.delay)
 	}
@@ -119,7 +118,7 @@ func (c *mockLightningClient) GetChannel(peerID []byte, channelPoint wire.OutPoi
 	return res, nil
 }
 
-func (c *mockLightningClient) GetPeerId(scid *basetypes.ShortChannelID) ([]byte, error) {
+func (c *mockLightningClient) GetPeerId(scid *lightning.ShortChannelID) ([]byte, error) {
 	return nil, ErrNotImplemented
 }
 func (c *mockLightningClient) GetNodeChannelCount(nodeID []byte) (int, error) {

--- a/lsps2/mocks.go
+++ b/lsps2/mocks.go
@@ -29,9 +29,10 @@ func (m *mockNodesService) GetNodes() []*shared.Node {
 }
 
 type mockOpeningService struct {
-	menu    []*shared.OpeningFeeParams
-	err     error
-	invalid bool
+	menu                     []*shared.OpeningFeeParams
+	err                      error
+	invalid                  bool
+	isCurrentChainFeeCheaper bool
 }
 
 func (m *mockOpeningService) GetFeeParamsMenu(
@@ -46,6 +47,13 @@ func (m *mockOpeningService) ValidateOpeningFeeParams(
 	publicKey *btcec.PublicKey,
 ) bool {
 	return !m.invalid
+}
+
+func (m *mockOpeningService) IsCurrentChainFeeCheaper(
+	token string,
+	params *shared.OpeningFeeParams,
+) bool {
+	return m.isCurrentChainFeeCheaper
 }
 
 type mockLsps2Store struct {

--- a/lsps2/mocks.go
+++ b/lsps2/mocks.go
@@ -1,0 +1,143 @@
+package lsps2
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/breez/lspd/basetypes"
+	"github.com/breez/lspd/chain"
+	"github.com/breez/lspd/lightning"
+	"github.com/breez/lspd/shared"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/wire"
+)
+
+var ErrNotImplemented = errors.New("not implemented")
+
+type mockNodesService struct {
+	node *shared.Node
+	err  error
+}
+
+func (m *mockNodesService) GetNode(token string) (*shared.Node, error) {
+	return m.node, m.err
+}
+
+func (m *mockNodesService) GetNodes() []*shared.Node {
+	return []*shared.Node{m.node}
+}
+
+type mockOpeningService struct {
+	menu    []*shared.OpeningFeeParams
+	err     error
+	invalid bool
+}
+
+func (m *mockOpeningService) GetFeeParamsMenu(
+	token string,
+	privateKey *btcec.PrivateKey,
+) ([]*shared.OpeningFeeParams, error) {
+	return m.menu, m.err
+}
+
+func (m *mockOpeningService) ValidateOpeningFeeParams(
+	params *shared.OpeningFeeParams,
+	publicKey *btcec.PublicKey,
+) bool {
+	return !m.invalid
+}
+
+type mockLsps2Store struct {
+	err           error
+	req           *RegisterBuy
+	registrations map[uint64]*BuyRegistration
+	delay         time.Duration
+}
+
+func (s *mockLsps2Store) RegisterBuy(ctx context.Context, req *RegisterBuy) error {
+	s.req = req
+	return s.err
+}
+
+func (s *mockLsps2Store) GetBuyRegistration(ctx context.Context, scid basetypes.ShortChannelID) (*BuyRegistration, error) {
+	if s.delay.Nanoseconds() != 0 {
+		<-time.After(s.delay)
+	}
+	reg, ok := s.registrations[uint64(scid)]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return reg, nil
+}
+
+func (s *mockLsps2Store) SetChannelOpened(ctx context.Context, channelOpened *ChannelOpened) error {
+	return s.err
+}
+
+func (s *mockLsps2Store) SetCompleted(ctx context.Context, registrationId uint64) error {
+	return nil
+}
+
+type mockLightningClient struct {
+	openResponses    []*wire.OutPoint
+	openRequests     []*lightning.OpenChannelRequest
+	getChanRequests  []*wire.OutPoint
+	getChanResponses []*lightning.GetChannelResult
+}
+
+func (c *mockLightningClient) GetInfo() (*lightning.GetInfoResult, error) {
+	return nil, ErrNotImplemented
+}
+func (c *mockLightningClient) IsConnected(destination []byte) (bool, error) {
+	return false, ErrNotImplemented
+}
+func (c *mockLightningClient) OpenChannel(req *lightning.OpenChannelRequest) (*wire.OutPoint, error) {
+	c.openRequests = append(c.openRequests, req)
+	if len(c.openResponses) < len(c.openRequests) {
+		return nil, fmt.Errorf("no responses available")
+	}
+
+	res := c.openResponses[len(c.openRequests)-1]
+	if res == nil {
+		return nil, fmt.Errorf("no response available")
+	}
+	return res, nil
+}
+
+func (c *mockLightningClient) GetChannel(peerID []byte, channelPoint wire.OutPoint) (*lightning.GetChannelResult, error) {
+	c.getChanRequests = append(c.getChanRequests, &channelPoint)
+	if len(c.getChanResponses) < len(c.getChanRequests) {
+		return nil, fmt.Errorf("no responses available")
+	}
+
+	res := c.getChanResponses[len(c.getChanRequests)-1]
+	if res == nil {
+		return nil, fmt.Errorf("no response available")
+	}
+	return res, nil
+}
+
+func (c *mockLightningClient) GetPeerId(scid *basetypes.ShortChannelID) ([]byte, error) {
+	return nil, ErrNotImplemented
+}
+func (c *mockLightningClient) GetNodeChannelCount(nodeID []byte) (int, error) {
+	return 0, ErrNotImplemented
+}
+func (c *mockLightningClient) GetClosedChannels(nodeID string, channelPoints map[string]uint64) (map[string]uint64, error) {
+	return nil, ErrNotImplemented
+}
+func (c *mockLightningClient) WaitOnline(peerID []byte, deadline time.Time) error {
+	return ErrNotImplemented
+}
+func (c *mockLightningClient) WaitChannelActive(peerID []byte, deadline time.Time) error {
+	return ErrNotImplemented
+}
+
+type mockFeeEstimator struct {
+}
+
+func (f *mockFeeEstimator) EstimateFeeRate(context.Context, chain.FeeStrategy) (*chain.FeeEstimation, error) {
+	return nil, ErrNotImplemented
+}

--- a/lsps2/mocks.go
+++ b/lsps2/mocks.go
@@ -79,6 +79,10 @@ func (s *mockLsps2Store) SetCompleted(ctx context.Context, registrationId uint64
 	return nil
 }
 
+func (s *mockLsps2Store) SavePromises(ctx context.Context, req *SavePromises) error {
+	return nil
+}
+
 type mockLightningClient struct {
 	openResponses    []*wire.OutPoint
 	openRequests     []*lightning.OpenChannelRequest

--- a/lsps2/scid.go
+++ b/lsps2/scid.go
@@ -4,7 +4,7 @@ import (
 	"crypto/rand"
 	"math/big"
 
-	"github.com/breez/lspd/basetypes"
+	"github.com/breez/lspd/lightning"
 )
 
 var one = big.NewInt(1)
@@ -13,12 +13,12 @@ var sixtyfour = big.NewInt(64)
 var twoPowSixtyfour = two.Exp(two, sixtyfour, nil)
 var maxUint64 = twoPowSixtyfour.Sub(twoPowSixtyfour, one)
 
-func newScid() (*basetypes.ShortChannelID, error) {
+func newScid() (*lightning.ShortChannelID, error) {
 	s, err := rand.Int(rand.Reader, maxUint64)
 	if err != nil {
 		return nil, err
 	}
 
-	scid := basetypes.ShortChannelID(s.Uint64())
+	scid := lightning.ShortChannelID(s.Uint64())
 	return &scid, nil
 }

--- a/lsps2/server.go
+++ b/lsps2/server.go
@@ -132,6 +132,15 @@ func (s *server) GetInfo(
 		return nil, status.New(codes.InternalError, "internal error").Err()
 	}
 
+	err = s.store.SavePromises(ctx, &SavePromises{
+		Menu:  m,
+		Token: *request.Token,
+	})
+	if err != nil {
+		log.Printf("Lsps2Server.GetInfo: store.SavePromises(%+v, %s) err: %v", m, *request.Token, err)
+		return nil, status.New(codes.InternalError, "internal error").Err()
+	}
+
 	menu := []*OpeningFeeParams{}
 	for _, p := range m {
 		menu = append(menu, &OpeningFeeParams{

--- a/lsps2/server_test.go
+++ b/lsps2/server_test.go
@@ -9,52 +9,8 @@ import (
 	"github.com/breez/lspd/lsps0"
 	"github.com/breez/lspd/lsps0/status"
 	"github.com/breez/lspd/shared"
-	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/stretchr/testify/assert"
 )
-
-type mockNodesService struct {
-	node *shared.Node
-	err  error
-}
-
-func (m *mockNodesService) GetNode(token string) (*shared.Node, error) {
-	return m.node, m.err
-}
-
-func (m *mockNodesService) GetNodes() []*shared.Node {
-	return []*shared.Node{m.node}
-}
-
-type mockOpeningService struct {
-	menu    []*shared.OpeningFeeParams
-	err     error
-	invalid bool
-}
-
-func (m *mockOpeningService) GetFeeParamsMenu(
-	token string,
-	privateKey *btcec.PrivateKey,
-) ([]*shared.OpeningFeeParams, error) {
-	return m.menu, m.err
-}
-
-func (m *mockOpeningService) ValidateOpeningFeeParams(
-	params *shared.OpeningFeeParams,
-	publicKey *btcec.PublicKey,
-) bool {
-	return !m.invalid
-}
-
-type mockLsps2Store struct {
-	err error
-	req *RegisterBuy
-}
-
-func (s *mockLsps2Store) RegisterBuy(ctx context.Context, req *RegisterBuy) error {
-	s.req = req
-	return s.err
-}
 
 var token = "blah"
 var node = func() *shared.Node {

--- a/lsps2/store.go
+++ b/lsps2/store.go
@@ -25,6 +25,7 @@ type BuyRegistration struct {
 	Id               uint64
 	LspId            string
 	PeerId           string // TODO: Make peerId in the registration a byte array.
+	Token            string
 	Scid             lightning.ShortChannelID
 	OpeningFeeParams shared.OpeningFeeParams
 	PaymentSizeMsat  *uint64

--- a/lsps2/store.go
+++ b/lsps2/store.go
@@ -12,6 +12,11 @@ import (
 	"github.com/btcsuite/btcd/wire"
 )
 
+type SavePromises struct {
+	Menu  []*shared.OpeningFeeParams
+	Token string
+}
+
 type RegisterBuy struct {
 	LspId            string
 	PeerId           string
@@ -59,6 +64,7 @@ var ErrScidExists = errors.New("scid exists")
 var ErrNotFound = errors.New("not found")
 
 type Lsps2Store interface {
+	SavePromises(ctx context.Context, req *SavePromises) error
 	RegisterBuy(ctx context.Context, req *RegisterBuy) error
 	GetBuyRegistration(ctx context.Context, scid lightning.ShortChannelID) (*BuyRegistration, error)
 	SetChannelOpened(ctx context.Context, channelOpened *ChannelOpened) error

--- a/lsps2/store.go
+++ b/lsps2/store.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/breez/lspd/basetypes"
+	"github.com/breez/lspd/lsps0"
 	"github.com/breez/lspd/shared"
 	"github.com/btcsuite/btcd/wire"
 )
@@ -33,9 +34,9 @@ type BuyRegistration struct {
 }
 
 func (b *BuyRegistration) IsExpired() bool {
-	t, err := time.Parse(basetypes.TIME_FORMAT, b.OpeningFeeParams.ValidUntil)
+	t, err := time.Parse(lsps0.TIME_FORMAT, b.OpeningFeeParams.ValidUntil)
 	if err != nil {
-		log.Printf("BuyRegistration.IsExpired(): time.Parse(%v, %v) error: %v", basetypes.TIME_FORMAT, b.OpeningFeeParams.ValidUntil, err)
+		log.Printf("BuyRegistration.IsExpired(): time.Parse(%v, %v) error: %v", lsps0.TIME_FORMAT, b.OpeningFeeParams.ValidUntil, err)
 		return true
 	}
 

--- a/lsps2/store.go
+++ b/lsps2/store.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/breez/lspd/basetypes"
+	"github.com/breez/lspd/lightning"
 	"github.com/breez/lspd/lsps0"
 	"github.com/breez/lspd/shared"
 	"github.com/btcsuite/btcd/wire"
@@ -15,7 +15,7 @@ import (
 type RegisterBuy struct {
 	LspId            string
 	PeerId           string
-	Scid             basetypes.ShortChannelID
+	Scid             lightning.ShortChannelID
 	OpeningFeeParams shared.OpeningFeeParams
 	PaymentSizeMsat  *uint64
 	Mode             OpeningMode
@@ -25,7 +25,7 @@ type BuyRegistration struct {
 	Id               uint64
 	LspId            string
 	PeerId           string // TODO: Make peerId in the registration a byte array.
-	Scid             basetypes.ShortChannelID
+	Scid             lightning.ShortChannelID
 	OpeningFeeParams shared.OpeningFeeParams
 	PaymentSizeMsat  *uint64
 	Mode             OpeningMode
@@ -59,7 +59,7 @@ var ErrNotFound = errors.New("not found")
 
 type Lsps2Store interface {
 	RegisterBuy(ctx context.Context, req *RegisterBuy) error
-	GetBuyRegistration(ctx context.Context, scid basetypes.ShortChannelID) (*BuyRegistration, error)
+	GetBuyRegistration(ctx context.Context, scid lightning.ShortChannelID) (*BuyRegistration, error)
 	SetChannelOpened(ctx context.Context, channelOpened *ChannelOpened) error
 	SetCompleted(ctx context.Context, registrationId uint64) error
 }

--- a/lsps2/store.go
+++ b/lsps2/store.go
@@ -3,9 +3,12 @@ package lsps2
 import (
 	"context"
 	"errors"
+	"log"
+	"time"
 
 	"github.com/breez/lspd/basetypes"
 	"github.com/breez/lspd/shared"
+	"github.com/btcsuite/btcd/wire"
 )
 
 type RegisterBuy struct {
@@ -17,8 +20,45 @@ type RegisterBuy struct {
 	Mode             OpeningMode
 }
 
+type BuyRegistration struct {
+	Id               uint64
+	LspId            string
+	PeerId           string // TODO: Make peerId in the registration a byte array.
+	Scid             basetypes.ShortChannelID
+	OpeningFeeParams shared.OpeningFeeParams
+	PaymentSizeMsat  *uint64
+	Mode             OpeningMode
+	ChannelPoint     *wire.OutPoint
+	IsComplete       bool
+}
+
+func (b *BuyRegistration) IsExpired() bool {
+	t, err := time.Parse(basetypes.TIME_FORMAT, b.OpeningFeeParams.ValidUntil)
+	if err != nil {
+		log.Printf("BuyRegistration.IsExpired(): time.Parse(%v, %v) error: %v", basetypes.TIME_FORMAT, b.OpeningFeeParams.ValidUntil, err)
+		return true
+	}
+
+	if time.Now().UTC().After(t) {
+		return true
+	}
+
+	return false
+}
+
+type ChannelOpened struct {
+	RegistrationId  uint64
+	Outpoint        *wire.OutPoint
+	FeeMsat         uint64
+	PaymentSizeMsat uint64
+}
+
 var ErrScidExists = errors.New("scid exists")
+var ErrNotFound = errors.New("not found")
 
 type Lsps2Store interface {
 	RegisterBuy(ctx context.Context, req *RegisterBuy) error
+	GetBuyRegistration(ctx context.Context, scid basetypes.ShortChannelID) (*BuyRegistration, error)
+	SetChannelOpened(ctx context.Context, channelOpened *ChannelOpened) error
+	SetCompleted(ctx context.Context, registrationId uint64) error
 }

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/breez/lspd/chain"
 	"github.com/breez/lspd/cln"
@@ -98,6 +100,7 @@ func main() {
 	lsps2Store := postgresql.NewLsps2Store(pool)
 	notificationService := notifications.NewNotificationService(notificationsStore)
 
+	ctx, cancel := context.WithCancel(context.Background())
 	openingService := shared.NewOpeningService(openingStore, nodesService)
 	var interceptors []interceptor.HtlcInterceptor
 	for _, node := range nodes {
@@ -123,7 +126,21 @@ func main() {
 				log.Fatalf("failed to initialize CLN client: %v", err)
 			}
 
-			interceptor := interceptor.NewInterceptHandler(client, node.NodeConfig, interceptStore, openingService, feeEstimator, feeStrategy, notificationService)
+			legacyHandler := interceptor.NewInterceptHandler(client, node.NodeConfig, interceptStore, openingService, feeEstimator, feeStrategy, notificationService)
+			lsps2Handler := lsps2.NewInterceptHandler(lsps2Store, openingService, client, feeEstimator, &lsps2.InterceptorConfig{
+				AdditionalChannelCapacitySat: uint64(node.NodeConfig.AdditionalChannelCapacity),
+				MinConfs:                     node.NodeConfig.MinConfs,
+				TargetConf:                   node.NodeConfig.TargetConf,
+				FeeStrategy:                  feeStrategy,
+				MinPaymentSizeMsat:           node.NodeConfig.MinPaymentSizeMsat,
+				MaxPaymentSizeMsat:           node.NodeConfig.MaxPaymentSizeMsat,
+				TimeLockDelta:                node.NodeConfig.TimeLockDelta,
+				HtlcMinimumMsat:              node.NodeConfig.MinHtlcMsat,
+				MppTimeout:                   time.Second * 90,
+			})
+			go lsps2Handler.Start(ctx)
+			combinedHandler := shared.NewCombinedHandler(lsps2Handler, legacyHandler)
+			htlcInterceptor, err = cln.NewClnHtlcInterceptor(node.NodeConfig, client, combinedHandler)
 			if err != nil {
 				log.Fatalf("failed to initialize CLN interceptor: %v", err)
 			}
@@ -163,6 +180,8 @@ func main() {
 		for _, interceptor := range interceptors {
 			interceptor.Stop()
 		}
+
+		cancel()
 	}
 
 	for _, interceptor := range interceptors {

--- a/main.go
+++ b/main.go
@@ -110,7 +110,7 @@ func main() {
 
 			client.StartListeners()
 			fwsync := lnd.NewForwardingHistorySync(client, interceptStore, forwardingStore)
-			interceptor := interceptor.NewInterceptHandler(client, node.NodeConfig, interceptStore, openingStore, feeEstimator, feeStrategy, notificationService)
+			interceptor := interceptor.NewInterceptHandler(client, node.NodeConfig, interceptStore, openingService, feeEstimator, feeStrategy, notificationService)
 			htlcInterceptor, err = lnd.NewLndHtlcInterceptor(node.NodeConfig, client, fwsync, interceptor)
 			if err != nil {
 				log.Fatalf("failed to initialize LND interceptor: %v", err)
@@ -123,7 +123,7 @@ func main() {
 				log.Fatalf("failed to initialize CLN client: %v", err)
 			}
 
-			interceptor := interceptor.NewInterceptHandler(client, node.NodeConfig, interceptStore, openingStore, feeEstimator, feeStrategy, notificationService)
+			interceptor := interceptor.NewInterceptHandler(client, node.NodeConfig, interceptStore, openingService, feeEstimator, feeStrategy, notificationService)
 			if err != nil {
 				log.Fatalf("failed to initialize CLN interceptor: %v", err)
 			}

--- a/main.go
+++ b/main.go
@@ -110,7 +110,7 @@ func main() {
 
 			client.StartListeners()
 			fwsync := lnd.NewForwardingHistorySync(client, interceptStore, forwardingStore)
-			interceptor := interceptor.NewInterceptor(client, node.NodeConfig, interceptStore, openingStore, feeEstimator, feeStrategy, notificationService)
+			interceptor := interceptor.NewInterceptHandler(client, node.NodeConfig, interceptStore, openingStore, feeEstimator, feeStrategy, notificationService)
 			htlcInterceptor, err = lnd.NewLndHtlcInterceptor(node.NodeConfig, client, fwsync, interceptor)
 			if err != nil {
 				log.Fatalf("failed to initialize LND interceptor: %v", err)
@@ -123,8 +123,7 @@ func main() {
 				log.Fatalf("failed to initialize CLN client: %v", err)
 			}
 
-			interceptor := interceptor.NewInterceptor(client, node.NodeConfig, interceptStore, openingStore, feeEstimator, feeStrategy, notificationService)
-			htlcInterceptor, err = cln.NewClnHtlcInterceptor(node.NodeConfig, client, interceptor)
+			interceptor := interceptor.NewInterceptHandler(client, node.NodeConfig, interceptStore, openingStore, feeEstimator, feeStrategy, notificationService)
 			if err != nil {
 				log.Fatalf("failed to initialize CLN interceptor: %v", err)
 			}

--- a/postgresql/intercept_store.go
+++ b/postgresql/intercept_store.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/breez/lspd/basetypes"
+	"github.com/breez/lspd/lightning"
 	"github.com/breez/lspd/shared"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/jackc/pgtype"
@@ -45,7 +45,7 @@ func (s *PostgresInterceptStore) PaymentInfo(htlcPaymentHash []byte) (string, *s
 
 	var cp *wire.OutPoint
 	if fundingTxID != nil {
-		cp, err = basetypes.NewOutPoint(fundingTxID, uint32(fundingTxOutnum.Int))
+		cp, err = lightning.NewOutPoint(fundingTxID, uint32(fundingTxOutnum.Int))
 		if err != nil {
 			log.Printf("invalid funding txid in database %x", fundingTxID)
 		}

--- a/postgresql/lsps2_store.go
+++ b/postgresql/lsps2_store.go
@@ -216,3 +216,24 @@ func (s *Lsps2Store) SetCompleted(ctx context.Context, registrationId uint64) er
 
 	return nil
 }
+
+func (s *Lsps2Store) SavePromises(
+	ctx context.Context,
+	req *lsps2.SavePromises,
+) error {
+	if len(req.Menu) == 0 {
+		return nil
+	}
+
+	rows := [][]interface{}{}
+	for _, p := range req.Menu {
+		rows = append(rows, []interface{}{p.Promise, req.Token})
+	}
+	_, err := s.pool.CopyFrom(
+		ctx,
+		pgx.Identifier{"lsps2", "promises"},
+		[]string{"promise", "token"},
+		pgx.CopyFromRows(rows),
+	)
+	return err
+}

--- a/postgresql/lsps2_store.go
+++ b/postgresql/lsps2_store.go
@@ -2,9 +2,14 @@ package postgresql
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
+	"github.com/breez/lspd/basetypes"
 	"github.com/breez/lspd/lsps2"
+	"github.com/breez/lspd/shared"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
 )
 
@@ -35,7 +40,7 @@ func (s *Lsps2Store) RegisterBuy(
 		 ,  params_max_client_to_self_delay
 		 ,  params_promise
 		 )
-		 VALUES ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?`,
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
 		req.LspId,
 		req.PeerId,
 		int64(uint64(req.Scid)),
@@ -54,6 +59,141 @@ func (s *Lsps2Store) RegisterBuy(
 		}
 
 		return err
+	}
+
+	return nil
+}
+
+func (s *Lsps2Store) GetBuyRegistration(ctx context.Context, scid basetypes.ShortChannelID) (*lsps2.BuyRegistration, error) {
+	row := s.pool.QueryRow(
+		ctx,
+		`SELECT r.id
+		,       r.lsp_id
+		,       r.peer_id
+		,       r.scid
+		,       r.mode
+		,       r.payment_size_msat
+		,       r.params_min_fee_msat
+		,       r.params_proportional
+		,       r.params_valid_until
+		,       r.params_min_lifetime
+		,       r.params_max_client_to_self_delay
+		,       r.params_promise
+		,       c.funding_tx_id
+		,       c.funding_tx_outnum
+		,       c.is_completed
+		 FROM lsps2.buy_registrations r
+		 LEFT JOIN lsps2.bought_channels c ON r.id = c.registration_id
+		 WHERE r.scid = $1`,
+		int64(uint64(scid)),
+	)
+	var db_id uint64
+	var db_lsp_id string
+	var db_peer_id string
+	var db_scid int64
+	var db_mode int
+	var db_payment_size_msat *int64
+	var db_params_min_fee_msat int64
+	var db_params_proportional uint32
+	var db_params_valid_until string
+	var db_params_min_lifetime uint32
+	var db_params_max_client_to_self_delay uint32
+	var db_params_promise string
+	var db_funding_tx_id []byte
+	var db_funding_tx_outnum uint32
+	var db_is_completed bool
+	err := row.Scan(
+		&db_id,
+		&db_lsp_id,
+		&db_peer_id,
+		&db_scid,
+		db_payment_size_msat,
+		&db_params_min_fee_msat,
+		&db_params_proportional,
+		&db_params_valid_until,
+		&db_params_min_lifetime,
+		&db_params_max_client_to_self_delay,
+		&db_params_promise,
+		&db_funding_tx_id,
+		&db_funding_tx_outnum,
+		&db_is_completed,
+	)
+	if err == pgx.ErrNoRows {
+		return nil, lsps2.ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var paymentSizeMsat *uint64
+	if db_payment_size_msat != nil {
+		p := uint64(*db_payment_size_msat)
+		paymentSizeMsat = &p
+	}
+
+	var cp *wire.OutPoint
+	if db_funding_tx_id != nil {
+		cp, err = basetypes.NewOutPoint(db_funding_tx_id, db_funding_tx_outnum)
+		if err != nil {
+			return nil, fmt.Errorf("invalid funding tx id in db: %x", db_funding_tx_id)
+		}
+	}
+
+	return &lsps2.BuyRegistration{
+		Id:     db_id,
+		LspId:  db_lsp_id,
+		PeerId: db_peer_id,
+		Scid:   basetypes.ShortChannelID(uint64(db_scid)),
+		OpeningFeeParams: shared.OpeningFeeParams{
+			MinFeeMsat:           uint64(db_params_min_fee_msat),
+			Proportional:         db_params_proportional,
+			ValidUntil:           db_params_valid_until,
+			MinLifetime:          db_params_min_lifetime,
+			MaxClientToSelfDelay: db_params_max_client_to_self_delay,
+			Promise:              db_params_promise,
+		},
+		PaymentSizeMsat: paymentSizeMsat,
+		Mode:            lsps2.OpeningMode(db_mode),
+		ChannelPoint:    cp,
+		IsComplete:      db_is_completed,
+	}, nil
+}
+
+func (s *Lsps2Store) SetChannelOpened(ctx context.Context, channelOpened *lsps2.ChannelOpened) error {
+	_, err := s.pool.Exec(
+		ctx,
+		`INSERT INTO lsps2.bought_channels (
+			registration_id,
+			funding_tx_id,
+			funding_tx_outnum,
+			fee_msat,
+			payment_size_msat,
+			is_completed
+		) VALUES ($1, $2, $3, $4, $5, false)`,
+		channelOpened.RegistrationId,
+		channelOpened.Outpoint.Hash[:],
+		channelOpened.Outpoint.Index,
+		int64(channelOpened.FeeMsat),
+		int64(channelOpened.PaymentSizeMsat),
+	)
+
+	return err
+}
+
+func (s *Lsps2Store) SetCompleted(ctx context.Context, registrationId uint64) error {
+	rows, err := s.pool.Exec(
+		ctx,
+		`UPDATE lsps2.bought_channels
+		 SET is_completed = true
+		 WHERE registration_id = $1`,
+		registrationId,
+	)
+	if err != nil {
+		return err
+	}
+
+	if rows.RowsAffected() == 0 {
+		return fmt.Errorf("no rows were updated")
 	}
 
 	return nil

--- a/postgresql/lsps2_store.go
+++ b/postgresql/lsps2_store.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/breez/lspd/basetypes"
+	"github.com/breez/lspd/lightning"
 	"github.com/breez/lspd/lsps2"
 	"github.com/breez/lspd/shared"
 	"github.com/btcsuite/btcd/wire"
@@ -64,7 +64,7 @@ func (s *Lsps2Store) RegisterBuy(
 	return nil
 }
 
-func (s *Lsps2Store) GetBuyRegistration(ctx context.Context, scid basetypes.ShortChannelID) (*lsps2.BuyRegistration, error) {
+func (s *Lsps2Store) GetBuyRegistration(ctx context.Context, scid lightning.ShortChannelID) (*lsps2.BuyRegistration, error) {
 	row := s.pool.QueryRow(
 		ctx,
 		`SELECT r.id
@@ -133,7 +133,7 @@ func (s *Lsps2Store) GetBuyRegistration(ctx context.Context, scid basetypes.Shor
 
 	var cp *wire.OutPoint
 	if db_funding_tx_id != nil {
-		cp, err = basetypes.NewOutPoint(db_funding_tx_id, db_funding_tx_outnum)
+		cp, err = lightning.NewOutPoint(db_funding_tx_id, db_funding_tx_outnum)
 		if err != nil {
 			return nil, fmt.Errorf("invalid funding tx id in db: %x", db_funding_tx_id)
 		}
@@ -143,7 +143,7 @@ func (s *Lsps2Store) GetBuyRegistration(ctx context.Context, scid basetypes.Shor
 		Id:     db_id,
 		LspId:  db_lsp_id,
 		PeerId: db_peer_id,
-		Scid:   basetypes.ShortChannelID(uint64(db_scid)),
+		Scid:   lightning.ShortChannelID(uint64(db_scid)),
 		OpeningFeeParams: shared.OpeningFeeParams{
 			MinFeeMsat:           uint64(db_params_min_fee_msat),
 			Proportional:         db_params_proportional,

--- a/postgresql/migrations/000014_lsps2_buy.down.sql
+++ b/postgresql/migrations/000014_lsps2_buy.down.sql
@@ -1,3 +1,5 @@
+DROP INDEX idx_lsps2_bought_channels_registration_id;
+DROP TABLE lsps2.bought_channels;
 DROP INDEX idx_lsps2_buy_registrations_valid_until;
 DROP INDEX idx_lsps2_buy_registrations_scid;
 DROP TABLE lsps2.buy_registrations;

--- a/postgresql/migrations/000014_lsps2_buy.down.sql
+++ b/postgresql/migrations/000014_lsps2_buy.down.sql
@@ -1,3 +1,4 @@
+DROP TABLE lsps2.promises;
 DROP INDEX idx_lsps2_bought_channels_registration_id;
 DROP TABLE lsps2.bought_channels;
 DROP INDEX idx_lsps2_buy_registrations_valid_until;

--- a/postgresql/migrations/000014_lsps2_buy.up.sql
+++ b/postgresql/migrations/000014_lsps2_buy.up.sql
@@ -15,3 +15,18 @@ CREATE TABLE lsps2.buy_registrations (
 );
 CREATE UNIQUE INDEX idx_lsps2_buy_registrations_scid ON lsps2.buy_registrations (scid);
 CREATE INDEX idx_lsps2_buy_registrations_valid_until ON lsps2.buy_registrations (params_valid_until);
+
+CREATE TABLE lsps2.bought_channels (
+	id bigserial PRIMARY KEY,
+	registration_id bigint NOT NULL,
+	funding_tx_id bytea NOT NULL,
+	funding_tx_outnum bigint NOT NULL,
+	fee_msat bigint NOT NULL,
+	payment_size_msat bigint NOT NULL,
+	is_completed boolean NOT NULL,
+	CONSTRAINT fk_buy_registration
+	  FOREIGN KEY(registration_id)
+	  REFERENCES lsps2.buy_registrations(id)
+	  ON DELETE CASCADE
+);
+CREATE INDEX idx_lsps2_bought_channels_registration_id ON lsps2.bought_channels (registration_id);

--- a/postgresql/migrations/000014_lsps2_buy.up.sql
+++ b/postgresql/migrations/000014_lsps2_buy.up.sql
@@ -1,8 +1,8 @@
 CREATE SCHEMA lsps2;
 CREATE TABLE lsps2.buy_registrations (
     id bigserial PRIMARY KEY, 
-    lsp_id bytea NOT NULL,
-    peer_id bytea NOT NULL,
+    lsp_id varchar NOT NULL,
+    peer_id varchar NOT NULL,
     scid bigint NOT NULL,
 	mode smallint NOT NULL,
 	payment_size_msat bigint NULL,

--- a/postgresql/migrations/000014_lsps2_buy.up.sql
+++ b/postgresql/migrations/000014_lsps2_buy.up.sql
@@ -11,7 +11,8 @@ CREATE TABLE lsps2.buy_registrations (
 	params_valid_until varchar NOT NULL,
 	params_min_lifetime bigint NOT NULL,
 	params_max_client_to_self_delay bigint NOT NULL,
-	params_promise varchar NOT NULL
+	params_promise varchar NOT NULL,
+	token VARCHAR NOT NULL
 );
 CREATE UNIQUE INDEX idx_lsps2_buy_registrations_scid ON lsps2.buy_registrations (scid);
 CREATE INDEX idx_lsps2_buy_registrations_valid_until ON lsps2.buy_registrations (params_valid_until);
@@ -30,3 +31,8 @@ CREATE TABLE lsps2.bought_channels (
 	  ON DELETE CASCADE
 );
 CREATE INDEX idx_lsps2_bought_channels_registration_id ON lsps2.bought_channels (registration_id);
+
+CREATE TABLE lsps2.promises (
+	promise varchar PRIMARY KEY,
+	token varchar NOT NULL
+)

--- a/postgresql/opening_store.go
+++ b/postgresql/opening_store.go
@@ -1,0 +1,57 @@
+package postgresql
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"time"
+
+	"github.com/breez/lspd/shared"
+	"github.com/jackc/pgx/v4/pgxpool"
+)
+
+type extendedParams struct {
+	Token  string                  `json:"token"`
+	Params shared.OpeningFeeParams `json:"fees_params"`
+}
+
+type PostgresOpeningStore struct {
+	pool *pgxpool.Pool
+}
+
+func NewPostgresOpeningStore(pool *pgxpool.Pool) *PostgresOpeningStore {
+	return &PostgresOpeningStore{pool: pool}
+}
+
+func (s *PostgresOpeningStore) GetFeeParamsSettings(token string) ([]*shared.OpeningFeeParamsSetting, error) {
+	rows, err := s.pool.Query(context.Background(), `SELECT validity, params FROM new_channel_params WHERE token=$1`, token)
+	if err != nil {
+		log.Printf("GetFeeParamsSettings(%v) error: %v", token, err)
+		return nil, err
+	}
+
+	var settings []*shared.OpeningFeeParamsSetting
+	for rows.Next() {
+		var validity int64
+		var param string
+		err = rows.Scan(&validity, &param)
+		if err != nil {
+			return nil, err
+		}
+
+		var params *shared.OpeningFeeParams
+		err := json.Unmarshal([]byte(param), &params)
+		if err != nil {
+			log.Printf("Failed to unmarshal fee param '%v': %v", param, err)
+			return nil, err
+		}
+
+		duration := time.Second * time.Duration(validity)
+		settings = append(settings, &shared.OpeningFeeParamsSetting{
+			Validity: duration,
+			Params:   params,
+		})
+	}
+
+	return settings, nil
+}

--- a/shared/combined_handler.go
+++ b/shared/combined_handler.go
@@ -1,0 +1,27 @@
+package shared
+
+import "log"
+
+type CombinedHandler struct {
+	handlers []InterceptHandler
+}
+
+func NewCombinedHandler(handlers ...InterceptHandler) *CombinedHandler {
+	return &CombinedHandler{
+		handlers: handlers,
+	}
+}
+
+func (c *CombinedHandler) Intercept(req InterceptRequest) InterceptResult {
+	for i, handler := range c.handlers {
+		res := handler.Intercept(req)
+		log.Printf("Intercept %+v. Interceptor %d returns %+v", req, i, res)
+		if res.Action != INTERCEPT_RESUME {
+			return res
+		}
+	}
+
+	return InterceptResult{
+		Action: INTERCEPT_RESUME,
+	}
+}

--- a/shared/extra_fee_record.go
+++ b/shared/extra_fee_record.go
@@ -1,0 +1,9 @@
+package shared
+
+import "github.com/lightningnetwork/lnd/tlv"
+
+var ExtraFeeTlvType tlv.Type = 65536
+
+func NewExtraFeeRecord(feeMsat *uint64) tlv.Record {
+	return tlv.MakePrimitiveRecord(ExtraFeeTlvType, feeMsat)
+}

--- a/shared/intercept_handler.go
+++ b/shared/intercept_handler.go
@@ -1,0 +1,64 @@
+package shared
+
+import (
+	"fmt"
+
+	"github.com/breez/lspd/lightning"
+	"github.com/btcsuite/btcd/wire"
+)
+
+type InterceptAction int
+
+const (
+	INTERCEPT_RESUME              InterceptAction = 0
+	INTERCEPT_RESUME_WITH_ONION   InterceptAction = 1
+	INTERCEPT_FAIL_HTLC_WITH_CODE InterceptAction = 2
+	INTERCEPT_IGNORE              InterceptAction = 3
+)
+
+type InterceptFailureCode uint16
+
+var (
+	FAILURE_TEMPORARY_CHANNEL_FAILURE            InterceptFailureCode = 0x1007
+	FAILURE_AMOUNT_BELOW_MINIMUM                 InterceptFailureCode = 0x100B
+	FAILURE_INCORRECT_CLTV_EXPIRY                InterceptFailureCode = 0x100D
+	FAILURE_TEMPORARY_NODE_FAILURE               InterceptFailureCode = 0x2002
+	FAILURE_UNKNOWN_NEXT_PEER                    InterceptFailureCode = 0x400A
+	FAILURE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS InterceptFailureCode = 0x400F
+)
+
+type InterceptRequest struct {
+	// Identifier that uniquely identifies this htlc.
+	// For cln, that's hash of the next onion or the shared secret.
+	Identifier         string
+	Scid               lightning.ShortChannelID
+	PaymentHash        []byte
+	IncomingAmountMsat uint64
+	OutgoingAmountMsat uint64
+	IncomingExpiry     uint32
+	OutgoingExpiry     uint32
+}
+
+func (r *InterceptRequest) PaymentId() string {
+	return fmt.Sprintf("%s|%x", r.Scid.ToString(), r.PaymentHash)
+}
+
+func (r *InterceptRequest) HtlcId() string {
+	return r.Identifier
+}
+
+type InterceptResult struct {
+	Action          InterceptAction
+	FailureCode     InterceptFailureCode
+	Destination     []byte
+	AmountMsat      uint64
+	FeeMsat         *uint64
+	TotalAmountMsat uint64
+	ChannelPoint    *wire.OutPoint
+	Scid            lightning.ShortChannelID
+	PaymentSecret   []byte
+}
+
+type InterceptHandler interface {
+	Intercept(req InterceptRequest) InterceptResult
+}

--- a/shared/opening_service.go
+++ b/shared/opening_service.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/breez/lspd/basetypes"
-	"github.com/breez/lspd/interceptor"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 )
@@ -21,27 +20,18 @@ type OpeningService interface {
 }
 
 type openingService struct {
-	store        interceptor.InterceptStore
+	store        OpeningStore
 	nodesService NodesService
 }
 
 func NewOpeningService(
-	store interceptor.InterceptStore,
+	store OpeningStore,
 	nodesService NodesService,
 ) OpeningService {
 	return &openingService{
 		store:        store,
 		nodesService: nodesService,
 	}
-}
-
-type OpeningFeeParams struct {
-	MinFeeMsat           uint64 `json:"min_fee_msat,string"`
-	Proportional         uint32 `json:"proportional"`
-	ValidUntil           string `json:"valid_until"`
-	MinLifetime          uint32 `json:"min_lifetime"`
-	MaxClientToSelfDelay uint32 `json:"max_client_to_self_delay"`
-	Promise              string `json:"promise"`
 }
 
 func (s *openingService) GetFeeParamsMenu(token string, privateKey *btcec.PrivateKey) ([]*OpeningFeeParams, error) {
@@ -55,10 +45,10 @@ func (s *openingService) GetFeeParamsMenu(token string, privateKey *btcec.Privat
 	for _, setting := range settings {
 		validUntil := time.Now().UTC().Add(setting.Validity)
 		params := &OpeningFeeParams{
-			MinFeeMsat:           setting.Params.MinMsat,
+			MinFeeMsat:           setting.Params.MinFeeMsat,
 			Proportional:         setting.Params.Proportional,
 			ValidUntil:           validUntil.Format(basetypes.TIME_FORMAT),
-			MinLifetime:          setting.Params.MaxIdleTime,
+			MinLifetime:          setting.Params.MinLifetime,
 			MaxClientToSelfDelay: setting.Params.MaxClientToSelfDelay,
 		}
 

--- a/shared/opening_service.go
+++ b/shared/opening_service.go
@@ -9,7 +9,7 @@ import (
 	"sort"
 	"time"
 
-	"github.com/breez/lspd/basetypes"
+	"github.com/breez/lspd/lsps0"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 )
@@ -47,7 +47,7 @@ func (s *openingService) GetFeeParamsMenu(token string, privateKey *btcec.Privat
 		params := &OpeningFeeParams{
 			MinFeeMsat:           setting.Params.MinFeeMsat,
 			Proportional:         setting.Params.Proportional,
-			ValidUntil:           validUntil.Format(basetypes.TIME_FORMAT),
+			ValidUntil:           validUntil.Format(lsps0.TIME_FORMAT),
 			MinLifetime:          setting.Params.MinLifetime,
 			MaxClientToSelfDelay: setting.Params.MaxClientToSelfDelay,
 		}
@@ -82,9 +82,9 @@ func (s *openingService) ValidateOpeningFeeParams(params *OpeningFeeParams, publ
 		return false
 	}
 
-	t, err := time.Parse(basetypes.TIME_FORMAT, params.ValidUntil)
+	t, err := time.Parse(lsps0.TIME_FORMAT, params.ValidUntil)
 	if err != nil {
-		log.Printf("validateOpeningFeeParams: time.Parse(%v, %v) error: %v", basetypes.TIME_FORMAT, params.ValidUntil, err)
+		log.Printf("validateOpeningFeeParams: time.Parse(%v, %v) error: %v", lsps0.TIME_FORMAT, params.ValidUntil, err)
 		return false
 	}
 

--- a/shared/opening_store.go
+++ b/shared/opening_store.go
@@ -1,0 +1,21 @@
+package shared
+
+import "time"
+
+type OpeningFeeParamsSetting struct {
+	Validity time.Duration
+	Params   *OpeningFeeParams
+}
+
+type OpeningFeeParams struct {
+	MinFeeMsat           uint64 `json:"min_msat,string"`
+	Proportional         uint32 `json:"proportional"`
+	ValidUntil           string `json:"valid_until"`
+	MinLifetime          uint32 `json:"max_idle_time"`
+	MaxClientToSelfDelay uint32 `json:"max_client_to_self_delay"`
+	Promise              string `json:"promise"`
+}
+
+type OpeningStore interface {
+	GetFeeParamsSettings(token string) ([]*OpeningFeeParamsSetting, error)
+}


### PR DESCRIPTION
Adds the htlc forwarding component for the LSPS2 implementation.
The forwarding logic is run in an event loop to avoid extensive locking mutexes.

This is a rather large PR, _please review carefully_. It will take time to review. Any nits will do.
The main part that is added is lsps2/intercept_handler.go, which is the interceptor for lsps2.

The old interceptor now has the same signature as the new one. And the magic of combining them is in shared/combined_handler.go

Some parts of this PR might make it hard to review.
- I moved some stuff to shared folders
- I moved the basetypes out of the basetypes folder
- I added an unrelated change for this specific PR, to store the used token with the generated opening_fee_params, because that was actually a prerequisite for this PR.

If those changes make it too complicated to review, I can put them in separate PRs.

TODO
- [x] Implement forwarding event loop for LSPS2 intercepts
- [x] Hook up the lsps2 interceptor with the current interceptor. If lsps2 can't handle it, because the scid is not an lsps2 scid, fall back to 'old' behavior.
- [x] Implement the lsps2 store methods on postgresql
- [x] Make it so that slow database calls don't affect the event loop flow
- [x] Restrict one scid to a maximum of one opened channel
- [x] Make the CLN plugin replay in-flight htlcs when lspd reconnects
- [ ] Make sure there is no potential for deadlocks when eventloop chan sizes are exceeded
- [x] Handle the case where an additional part comes in after the payment is ready to forward
- [x] Make sure a payment can never be completed twice (that would panic, because the ready chan is closed)
- [x] Add integration tests
- [x] Handle expired fee params by checking current chain fees.