### PR TITLE
LND lsp CLN client compatibility

### DIFF
--- a/.github/actions/setup-clightning/action.yaml
+++ b/.github/actions/setup-clightning/action.yaml
@@ -74,6 +74,7 @@ runs:
     - name: Install dependencies
       if: steps.cache-core-lightning.outputs.cache-hit != 'true'
       run: |
+        sudo apt-get update -y
         sudo apt-get install -y autoconf automake build-essential git libtool libgmp-dev libsqlite3-dev python3 python3-pip net-tools zlib1g-dev libsodium-dev gettext valgrind libpq-dev shellcheck cppcheck libsecp256k1-dev jq 
         sudo apt-get remove -y protobuf-compiler
         curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.12.0/protoc-3.12.0-linux-x86_64.zip

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -83,7 +83,7 @@ jobs:
       - setup-lnd-lsp
       - setup-cln
       - build-lspd
-    name: test ${{ matrix.implementation }} ${{ matrix.test }}
+    name: test ${{ matrix.lsp }}-lsp ${{ matrix.client }}-client ${{ matrix.test }}
     strategy:
       max-parallel: 6
       matrix:
@@ -103,10 +103,18 @@ jobs:
           testOfflineNotificationRegularForward,
           testOfflineNotificationZeroConfChannel,
         ]
-        implementation: [
+        lsp: [
           LND,
           CLN
         ]
+        client: [
+          LND,
+          CLN
+        ]
+        exclude:
+          - lsp: CLN
+            client: LND
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -114,8 +122,8 @@ jobs:
       - name: Run and Process Test State
         uses: ./.github/actions/test-lspd
         with:
-          TESTRE: "TestLspd/${{ matrix.implementation }}-lspd:_${{ matrix.test }}"
-          artifact-name: TestLspd-${{ matrix.implementation }}-lspd_${{ matrix.test }}
+          TESTRE: "TestLspd/${{ matrix.lsp }}-lsp-${{ matrix.client}}-client:_${{ matrix.test }}"
+          artifact-name: TestLspd-${{ matrix.lsp }}-lsp-${{ matrix.client}}-client_${{ matrix.test }}
           bitcoin-version: ${{ env.BITCOIN_VERSION }}
           LSP_REF: ${{ env.LSP_REF }}
           CLIENT_REF: ${{ env.CLIENT_REF }}

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,11 @@ type NodeConfig struct {
 	// configured node, so it's obvious which node an rpc call is meant for.
 	Tokens []string `json:"tokens"`
 
+	// If the used token is in the LegacyOnionTokens array, the forwarded htlc
+	// will have the legacy onion format. As per the time of writing breezmobile
+	// requires the legacy onion format.
+	LegacyOnionTokens []string `json:"legacyOnionTokens"`
+
 	// The network location of the lightning node, e.g. `12.34.56.78:9012` or
 	// `localhost:10011`
 	Host string `json:"host"`

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/aws/aws-sdk-go v1.34.0
-	github.com/breez/lntest v0.0.26
+	github.com/breez/lntest v0.0.28
 	github.com/btcsuite/btcd v0.23.5-0.20230228185050-38331963bddd
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.2

--- a/itest/cln_breez_client.go
+++ b/itest/cln_breez_client.go
@@ -38,6 +38,9 @@ def on_openchannel(openchannel, plugin, **kwargs):
 	plugin.log(repr(openchannel))
 	mindepth = int(0)
 
+	if openchannel['funding_msat'] == 200000000:
+	    return {'result': 'continue'}
+
 	plugin.log(f"This peer is in the zeroconf allowlist, setting mindepth={mindepth}")
 	return {'result': 'continue', 'mindepth': mindepth}
 

--- a/itest/lspd_test.go
+++ b/itest/lspd_test.go
@@ -14,8 +14,19 @@ var defaultTimeout time.Duration = time.Second * 120
 
 func TestLspd(t *testing.T) {
 	testCases := allTestCases
-	runTests(t, testCases, "LND-lspd", lndLspFunc, lndClientFunc)
-	runTests(t, testCases, "CLN-lspd", clnLspFunc, clnClientFunc)
+	runTests(t, testCases, "LND-lsp-CLN-client", lndLspFunc, clnClientFunc)
+	runTests(t, testCases, "LND-lsp-LND-client", legacyOnionLndLspFunc, lndClientFunc)
+	runTests(t, testCases, "CLN-lsp-CLN-client", clnLspFunc, clnClientFunc)
+}
+
+func legacyOnionLndLspFunc(h *lntest.TestHarness, m *lntest.Miner, mem *mempoolApi, c *config.NodeConfig) LspNode {
+	cfg := c
+	if cfg == nil {
+		cfg = &config.NodeConfig{}
+	}
+
+	cfg.LegacyOnionTokens = []string{"hello"}
+	return lndLspFunc(h, m, mem, cfg)
 }
 
 func lndLspFunc(h *lntest.TestHarness, m *lntest.Miner, mem *mempoolApi, c *config.NodeConfig) LspNode {

--- a/itest/notification_test.go
+++ b/itest/notification_test.go
@@ -168,6 +168,23 @@ func testOfflineNotificationRegularForward(p *testParams) {
 	})
 	log.Printf(bobInvoice.Bolt11)
 
+	invoiceWithHint := bobInvoice.Bolt11
+	if !ContainsHopHint(p.t, bobInvoice.Bolt11) {
+		chans := p.BreezClient().Node().GetChannels()
+		assert.Len(p.t, chans, 1)
+
+		var id lntest.ShortChannelID
+		if chans[0].RemoteAlias != nil {
+			id = *chans[0].RemoteAlias
+		} else if chans[0].LocalAlias != nil {
+			id = *chans[0].LocalAlias
+		} else {
+			id = chans[0].ShortChannelID
+		}
+		invoiceWithHint = AddHopHint(p.BreezClient(), bobInvoice.Bolt11, p.Lsp(), id, nil)
+	}
+	log.Printf("invoice with hint: %v", invoiceWithHint)
+
 	log.Printf("Bob going offline")
 	p.BreezClient().Stop()
 
@@ -176,7 +193,7 @@ func testOfflineNotificationRegularForward(p *testParams) {
 	<-time.After(htlcInterceptorDelay)
 
 	log.Printf("Alice paying")
-	payResp := alice.Pay(bobInvoice.Bolt11)
+	payResp := alice.Pay(invoiceWithHint)
 	invoiceResult := p.BreezClient().Node().GetInvoice(bobInvoice.PaymentHash)
 
 	assert.Equal(p.t, payResp.PaymentPreimage, invoiceResult.PaymentPreimage)

--- a/itest/zero_reserve_test.go
+++ b/itest/zero_reserve_test.go
@@ -61,4 +61,10 @@ func testZeroReserve(p *testParams) {
 	assert.Equal(p.t, c.RemoteReserveMsat, c.CapacityMsat/100)
 	log.Printf("local reserve: %d, remote reserve: %d", c.LocalReserveMsat, c.RemoteReserveMsat)
 	assert.Zero(p.t, c.LocalReserveMsat)
+
+	lspInvoice := p.lsp.LightningNode().CreateBolt11Invoice(&lntest.CreateInvoiceOptions{
+		AmountMsat: innerAmountMsat - 1,
+	})
+	<-time.After(time.Second * 1)
+	p.BreezClient().Node().Pay(lspInvoice.Bolt11)
 }


### PR DESCRIPTION
This PR adds compatibility between the LND lsp and an sdk client.

A config parameter is added: `legacyOnionTokens`. If you're running an LND lsp, and you are serving breezmobile clients, _every_ token used to connect to the LSP from these types of clients must be put in the `legacyOnionTokens` array. If the token is not in that array, but you are routing to a breezmobile client, the client will not accept the htlc.

In that sense, this is a breaking change, because without the tokens in that config option, you will not be able to route to breezmobile clients anymore.

Requires an update to LND to be able to serve sdk clients: https://github.com/breez/lnd/pull/9