### PR TITLE
Cleanup expired notification urls

### DIFF
--- a/main.go
+++ b/main.go
@@ -103,8 +103,11 @@ func main() {
 	notificationService := notifications.NewNotificationService(notificationsStore)
 	go notificationService.Start(ctx)
 	openingService := common.NewOpeningService(openingStore, nodesService)
-	cleanupService := lsps2.NewCleanupService(lsps2Store)
-	go cleanupService.Start(ctx)
+	lsps2CleanupService := lsps2.NewCleanupService(lsps2Store)
+	go lsps2CleanupService.Start(ctx)
+	notificationCleanupService := notifications.NewCleanupService(notificationsStore)
+	go notificationCleanupService.Start(ctx)
+
 	var interceptors []interceptor.HtlcInterceptor
 	for _, node := range nodes {
 		var htlcInterceptor interceptor.HtlcInterceptor

--- a/notifications/cleanup.go
+++ b/notifications/cleanup.go
@@ -1,0 +1,41 @@
+package notifications
+
+import (
+	"context"
+	"log"
+	"time"
+)
+
+type CleanupService struct {
+	store Store
+}
+
+// The interval to clean unused promises and buy registrations.
+var CleanupInterval time.Duration = time.Hour
+
+// The expiry duration is the time until a non-refreshed webhook url expires.
+// Currently set to 4 weeks.
+var ExpiryDuration time.Duration = time.Hour * 24 * 28
+
+func NewCleanupService(store Store) *CleanupService {
+	return &CleanupService{
+		store: store,
+	}
+}
+
+// Periodically cleans up expired webhook urls.
+func (c *CleanupService) Start(ctx context.Context) {
+	for {
+		before := time.Now().Add(-ExpiryDuration)
+		err := c.store.RemoveExpired(ctx, before)
+		if err != nil {
+			log.Printf("Failed to remove expired webhook urls before %v: %v", before, err)
+		}
+		select {
+		case <-time.After(CleanupInterval):
+			continue
+		case <-ctx.Done():
+			return
+		}
+	}
+}

--- a/notifications/store.go
+++ b/notifications/store.go
@@ -2,9 +2,11 @@ package notifications
 
 import (
 	"context"
+	"time"
 )
 
 type Store interface {
 	Register(ctx context.Context, pubkey string, url string) error
 	GetRegistrations(ctx context.Context, pubkey string) ([]string, error)
+	RemoveExpired(ctx context.Context, before time.Time) error
 }

--- a/postgresql/notifications_store.go
+++ b/postgresql/notifications_store.go
@@ -74,3 +74,16 @@ func (s *NotificationsStore) GetRegistrations(
 
 	return result, nil
 }
+
+func (s *NotificationsStore) RemoveExpired(
+	ctx context.Context,
+	before time.Time,
+) error {
+	_, err := s.pool.Exec(
+		ctx,
+		`DELETE FROM public.notification_subscriptions
+		 WHERE refreshed_at < $1`,
+		before.UnixMicro())
+
+	return err
+}


### PR DESCRIPTION
- Make sure we call notification webhooks simultaneously
- Add a timeout (7 seconds) to calling notification webhooks
- Cleanup notification webhooks that have not been refreshed for 4 weeks