### PR TITLE
also notify when the peer is online

### DIFF
--- a/main.go
+++ b/main.go
@@ -98,9 +98,10 @@ func main() {
 	forwardingStore := postgresql.NewForwardingEventStore(pool)
 	notificationsStore := postgresql.NewNotificationsStore(pool)
 	lsps2Store := postgresql.NewLsps2Store(pool)
-	notificationService := notifications.NewNotificationService(notificationsStore)
 
 	ctx, cancel := context.WithCancel(context.Background())
+	notificationService := notifications.NewNotificationService(notificationsStore)
+	go notificationService.Start(ctx)
 	openingService := common.NewOpeningService(openingStore, nodesService)
 	cleanupService := lsps2.NewCleanupService(lsps2Store)
 	go cleanupService.Start(ctx)


### PR DESCRIPTION
Greenlight nodes stay online for 5 minutes after the client went offline. In that time period, the client is not notified about pending htlcs, because the lsp sees it as online.

This PR makes lspd notify on every incoming htlc when a client is subscribed to notifications, rather than only when the peer is offline. 

This will bridge the 5 minute gap.
The webhooks will be chatty. Multipart payments will push notifications for every htlc. 