### PR TITLE
test lspd still functions after node restart

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -88,6 +88,7 @@ jobs:
       max-parallel: 4
       matrix:
         test: [
+          testRestartLspNode,
           testOpenZeroConfChannelOnReceive,
           testOpenZeroConfSingleHtlc,
           testZeroReserve,

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -9,6 +9,10 @@ env:
   CLIENT_REF: 'v0.16.4-breez-3'
   GO_VERSION: '^1.19'
   CLN_VERSION: 'v23.11'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
 
   setup-bitcoin-core:

--- a/cln/custom_msg_client.go
+++ b/cln/custom_msg_client.go
@@ -161,7 +161,11 @@ func (c *CustomMsgClient) Send(msg *lightning.CustomMessage) error {
 	binary.BigEndian.PutUint16(t[:], uint16(msg.Type))
 
 	m := hex.EncodeToString(t[:]) + hex.EncodeToString(msg.Data)
-	_, err := c.client.client.SendCustomMessage(msg.PeerId, m)
+	client, err := c.client.getClient()
+	if err != nil {
+		return err
+	}
+	_, err = client.SendCustomMessage(msg.PeerId, m)
 	return err
 }
 

--- a/itest/lspd_test.go
+++ b/itest/lspd_test.go
@@ -226,4 +226,8 @@ var allTestCases = []*testCase{
 		isLsps2:       true,
 		skipCreateLsp: true,
 	},
+	{
+		name: "testRestartLspNode",
+		test: testRestartLspNode,
+	},
 }

--- a/itest/restart_lsp_node_test.go
+++ b/itest/restart_lsp_node_test.go
@@ -1,0 +1,75 @@
+package itest
+
+import (
+	"log"
+	"time"
+
+	"github.com/breez/lntest"
+	lspd "github.com/breez/lspd/rpc"
+	"github.com/stretchr/testify/assert"
+)
+
+func testRestartLspNode(p *testParams) {
+	alice := lntest.NewClnNode(p.h, p.m, "Alice")
+	alice.Start()
+	alice.Fund(10000000)
+	p.lsp.LightningNode().Fund(10000000)
+
+	log.Print("Opening channel between Alice and the lsp")
+	channel := alice.OpenChannel(p.lsp.LightningNode(), &lntest.OpenChannelOptions{
+		AmountSat: publicChanAmount,
+	})
+	alice.WaitForChannelReady(channel)
+
+	log.Printf("Adding bob's invoices")
+	outerAmountMsat := uint64(2100000)
+	innerAmountMsat := calculateInnerAmountMsat(p.lsp, outerAmountMsat, nil)
+	description := "Please pay me"
+	innerInvoice, outerInvoice := GenerateInvoices(p.BreezClient(),
+		generateInvoicesRequest{
+			innerAmountMsat: innerAmountMsat,
+			outerAmountMsat: outerAmountMsat,
+			description:     description,
+			lsp:             p.lsp,
+		})
+	p.BreezClient().SetHtlcAcceptor(innerAmountMsat)
+
+	log.Print("Connecting bob to lspd")
+	p.BreezClient().Node().ConnectPeer(p.lsp.LightningNode())
+
+	log.Printf("Registering payment with lsp")
+	RegisterPayment(p.lsp, &lspd.PaymentInformation{
+		PaymentHash:        innerInvoice.paymentHash,
+		PaymentSecret:      innerInvoice.paymentSecret,
+		Destination:        p.BreezClient().Node().NodeId(),
+		IncomingAmountMsat: int64(outerAmountMsat),
+		OutgoingAmountMsat: int64(innerAmountMsat),
+	}, false)
+
+	log.Printf("stopping lsp lightning node")
+	p.lsp.LightningNode().Stop()
+	log.Printf("waiting %v to allow lsp lightning node to stop completely", htlcInterceptorDelay)
+	<-time.After(htlcInterceptorDelay)
+	log.Printf("starting lsp lightning node again")
+	p.lsp.LightningNode().Start()
+
+	// TODO: Fix race waiting for htlc interceptor.
+	log.Printf("Waiting %v to allow htlc interceptor to activate.", htlcInterceptorDelay)
+	<-time.After(htlcInterceptorDelay)
+
+	log.Printf("Connect Bob to LSP again")
+	p.BreezClient().Node().ConnectPeer(p.lsp.LightningNode())
+
+	log.Printf("Alice paying")
+	payResp := alice.Pay(outerInvoice.bolt11)
+	bobInvoice := p.BreezClient().Node().GetInvoice(payResp.PaymentHash)
+
+	assert.Equal(p.t, payResp.PaymentPreimage, bobInvoice.PaymentPreimage)
+	assert.Equal(p.t, innerAmountMsat, bobInvoice.AmountReceivedMsat)
+
+	// Make sure capacity is correct
+	chans := p.BreezClient().Node().GetChannels()
+	assert.Equal(p.t, 1, len(chans))
+	c := chans[0]
+	AssertChannelCapacity(p.t, outerAmountMsat, c.CapacityMsat)
+}


### PR DESCRIPTION
Make sure lspd still functions are a restart of the node.
Fixes a problem where the cln client would stop working after the restart of the core lightning node.