### PR TITLE
upgrade cln to v24.02

### DIFF
--- a/.github/actions/setup-clightning/action.yaml
+++ b/.github/actions/setup-clightning/action.yaml
@@ -5,7 +5,7 @@ inputs:
   checkout-version:
     description: Core lightning version
     required: true
-    default: 'v23.11'
+    default: 'v24.02'
 
 runs:
   using: 'composite'

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -8,7 +8,7 @@ env:
   LSP_REF: 'breez-node-v0.17.2-beta'
   CLIENT_REF: 'v0.16.4-breez-3'
   GO_VERSION: '^1.19'
-  CLN_VERSION: 'v23.11'
+  CLN_VERSION: 'v24.02'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ env:
   LSPD_GO_VERSION: 1.21.0
   LND_GO_VERSION: 1.21.0
   LND_REF: 0c939786ced78a981bd77c7da628bfcf86ada568
-  CLN_REF: v23.11.2
+  CLN_REF: v24.02
 
 jobs:
   lspd:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The lsp supports probing non-mpp payments if the payment hash for probing is sha
 In order to run the integration tests, you need:
 - Docker running
 - python3 installed
-- A development build of lightningd v23.11
+- lightningd v24.02
 - lnd v0.17.2 lsp version https://github.com/breez/lnd/commit/0c939786ced78a981bd77c7da628bfcf86ada568
 - lnd v0.16.4 breez client version https://github.com/breez/lnd/commit/b9b7d37852321146dd7171809d673141fe1137bf
 - bitcoind (tested with v23.0)

--- a/deploy/deploy.yml
+++ b/deploy/deploy.yml
@@ -241,7 +241,7 @@ Resources:
             chmod 755 /etc/lightningd/
             git clone https://github.com/ElementsProject/lightning.git /opt/lightning
             cd /opt/lightning
-            git checkout v23.11
+            git checkout v24.02
             ./configure
             make
             make install

--- a/deploy/deploy.yml
+++ b/deploy/deploy.yml
@@ -235,7 +235,6 @@ Resources:
             lsp-listen=127.0.0.1:12312
             max-concurrent-htlcs=30
             dev-allowdustreserve=true
-            allow-deprecated-apis=true
             log-file=/var/log/lightningd/lightningd.log
             EOL
             chmod 755 /etc/lightningd/

--- a/deploy/lspd-install.sh
+++ b/deploy/lspd-install.sh
@@ -166,7 +166,6 @@ plugin=/home/lightning/.lightning/plugins/lspd_cln_plugin
 lsp-listen=127.0.0.1:12312
 max-concurrent-htlcs=30
 dev-allowdustreserve=true
-allow-deprecated-apis=true
 log-file=/var/log/lightningd/lightningd.log
 EOL
 chmod 755 /etc/lightningd/

--- a/deploy/lspd-install.sh
+++ b/deploy/lspd-install.sh
@@ -172,7 +172,7 @@ EOL
 chmod 755 /etc/lightningd/
 git clone https://github.com/ElementsProject/lightning.git /opt/lightning
 cd /opt/lightning
-git checkout v23.11
+git checkout v24.02
 ./configure
 make
 make install

--- a/docs/CLN.md
+++ b/docs/CLN.md
@@ -67,7 +67,6 @@ In order to run lspd on top of CLN, you need to run the lspd process and run cln
     - `--plugin=/path/to/lspd_cln_plugin`: to use lspd as plugin
     - `--max-concurrent-htlcs=30`: In order to use zero reserve channels on the client side, (local max_accepted_htlcs + remote max_accepted_htlcs + 2) * dust limit must be lower than the channel capacity. Reduce max-concurrent-htlcs or increase channel capacity accordingly.
     - `--dev-allowdustreserve=true`: In order to allow zero reserve on the client side (requires developer mode turned on)
-    - `--allow-deprecated-apis=true`: lspd currently uses a deprecated api, so needs this flag set.
     - `--lsp-listen=127.0.0.1:<port>`: Set on which port the lspd_cln_plugin will listen for lspd communication, must be the same port that is used in pluginAddress parameter in NODES env variable.
 1. Run lspd
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/GoWebProd/uuid7 v0.0.0-20230623091058-5f5954faed6a
 	github.com/aws/aws-sdk-go v1.34.0
-	github.com/breez/lntest v0.0.29
+	github.com/breez/lntest v0.0.30-0.20240301123156-3c1dcbf88c1d
 	github.com/btcsuite/btcd v0.23.5-0.20230905170901-80f5a0ffdf36
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -174,6 +174,8 @@ github.com/breez/lnd v0.15.0-beta.rc6.0.20231122093500-0c939786ced7 h1:RLHCG90jB
 github.com/breez/lnd v0.15.0-beta.rc6.0.20231122093500-0c939786ced7/go.mod h1:AOHMNILUI56HaVlVMai+ComGHsxMzMMCoxqFwN0wmvw=
 github.com/breez/lntest v0.0.29 h1:frB7NwT2KxMpNFiiFGuKDt1u8Pzexsb2Wrcgfk7mK1M=
 github.com/breez/lntest v0.0.29/go.mod h1:TYaPUDOmJyag/+ezQFvMD3Qqwos8QIEE36CP06gwQUU=
+github.com/breez/lntest v0.0.30-0.20240301123156-3c1dcbf88c1d h1:7MMuYkpZjlHLhzRcH2K7G4Lgl8t2e/CD+Zo1ysPl0oA=
+github.com/breez/lntest v0.0.30-0.20240301123156-3c1dcbf88c1d/go.mod h1:TYaPUDOmJyag/+ezQFvMD3Qqwos8QIEE36CP06gwQUU=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c/go.mod h1:tjmYdS6MLJ5/s0Fj4DbLgSbDHbEqLJrtnHecBFkdz5M=
 github.com/btcsuite/btcd v0.22.0-beta.0.20220204213055-eaf0459ff879/go.mod h1:osu7EoKiL36UThEgzYPqdRaxeo0NU8VoXqgcnwpey0g=

--- a/itest/cln_breez_client.go
+++ b/itest/cln_breez_client.go
@@ -91,7 +91,6 @@ func newClnBreezClient(h *lntest.TestHarness, m *lntest.Miner, name string) Bree
 		// reserve channel. Relevant code:
 		// https://github.com/ElementsProject/lightning/blob/774d16a72e125e4ae4e312b9e3307261983bec0e/openingd/openingd.c#L481-L520
 		"--max-concurrent-htlcs=30",
-		"--experimental-anchors",
 		"--developer",
 	)
 

--- a/itest/cln_lspd_node.go
+++ b/itest/cln_lspd_node.go
@@ -61,8 +61,6 @@ func NewClnLspdNode(h *lntest.TestHarness, m *lntest.Miner, mem *mempoolApi, nam
 		fmt.Sprintf("--cltv-delta=%d", lspCltvDelta),
 		"--max-concurrent-htlcs=30",
 		"--dev-allowdustreserve=true",
-		"--allow-deprecated-apis=true",
-		"--experimental-anchors",
 		"--developer",
 	}
 	lightningNode := lntest.NewClnNode(h, m, name, args...)

--- a/itest/cln_lspd_node.go
+++ b/itest/cln_lspd_node.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/breez/lntest"
 	"github.com/breez/lspd/config"
@@ -157,6 +158,7 @@ func (c *ClnLspNode) Start() {
 		},
 	})
 
+	<-time.After(time.Second)
 	conn, err := grpc.Dial(
 		c.lspBase.grpcAddress,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),

--- a/itest/lnd_lspd_node.go
+++ b/itest/lnd_lspd_node.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/breez/lntest"
 	"github.com/breez/lspd/config"
@@ -180,6 +181,7 @@ func (c *LndLspNode) Start() {
 		},
 	})
 
+	<-time.After(time.Second)
 	conn, err := grpc.Dial(
 		c.lspBase.grpcAddress,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),

--- a/itest/lsps2_zero_conf_utxo_test.go
+++ b/itest/lsps2_zero_conf_utxo_test.go
@@ -27,6 +27,8 @@ func testLsps2ZeroConfUtxo(p *testParams) {
 
 	tempaddr := lsp.LightningNode().GetNewAddress()
 	p.m.SendToAddress(tempaddr, 210000)
+	reserveaddr := lsp.LightningNode().GetNewAddress()
+	p.m.SendToAddress(reserveaddr, 50000)
 	p.m.MineBlocks(6)
 	lsp.LightningNode().WaitForSync()
 

--- a/itest/zero_conf_utxo_test.go
+++ b/itest/zero_conf_utxo_test.go
@@ -27,6 +27,8 @@ func testOpenZeroConfUtxo(p *testParams) {
 
 	tempaddr := lsp.LightningNode().GetNewAddress()
 	p.m.SendToAddress(tempaddr, 210000)
+	reserveaddr := lsp.LightningNode().GetNewAddress()
+	p.m.SendToAddress(reserveaddr, 50000)
 	p.m.MineBlocks(6)
 	lsp.LightningNode().WaitForSync()
 


### PR DESCRIPTION
This PR upgrades the cln version used to 24.02.
The only necessary changes are to the integration tests and to the docs.

With cln 24.02 it's no longer necessary to run cln with `--experimental-anchors`, since anchor channels are now the default channel type.
The `--allow-deprecated-apis` flag was also removed, because it's not necessary to run CLN with this flag (this was already not necessary in the last version of lspd)