### PR TITLE
insert htlc used for channel open

### DIFF
--- a/history/store.go
+++ b/history/store.go
@@ -26,6 +26,16 @@ type Forward struct {
 	ResolvedTime time.Time
 }
 
+type OpenChannelHtlc struct {
+	NodeId             []byte
+	PeerId             []byte
+	ChannelPoint       *wire.OutPoint
+	OriginalAmountMsat uint64
+	ForwardAmountMsat  uint64
+	IncomingAmountMsat uint64
+	ForwardTime        time.Time
+}
+
 type Store interface {
 	UpdateChannels(ctx context.Context, updates []*ChannelUpdate) error
 	InsertForwards(ctx context.Context, forwards []*Forward, nodeId []byte) error
@@ -33,4 +43,5 @@ type Store interface {
 	FetchClnForwardOffsets(ctx context.Context, nodeId []byte) (uint64, uint64, error)
 	SetClnForwardOffsets(ctx context.Context, nodeId []byte, created uint64, updated uint64) error
 	FetchLndForwardOffset(ctx context.Context, nodeId []byte) (*time.Time, error)
+	AddOpenChannelHtlc(ctx context.Context, htlc *OpenChannelHtlc) error
 }

--- a/lsps2/mocks.go
+++ b/lsps2/mocks.go
@@ -117,6 +117,9 @@ func (s *mockHistoryStore) SetClnForwardOffsets(ctx context.Context, nodeId []by
 func (s *mockHistoryStore) FetchLndForwardOffset(ctx context.Context, nodeId []byte) (*time.Time, error) {
 	return nil, ErrNotImplemented
 }
+func (s *mockHistoryStore) AddOpenChannelHtlc(ctx context.Context, htlc *history.OpenChannelHtlc) error {
+	return nil
+}
 
 type mockLightningClient struct {
 	openResponses    []*wire.OutPoint

--- a/postgresql/history_store.go
+++ b/postgresql/history_store.go
@@ -345,3 +345,29 @@ func (s *HistoryStore) SetClnForwardOffsets(
 	)
 	return err
 }
+
+func (s *HistoryStore) AddOpenChannelHtlc(ctx context.Context, htlc *history.OpenChannelHtlc) error {
+	// TODO: Find an identifier equal to the forwarding_history identifier.
+	_, err := s.pool.Exec(ctx, `
+	INSERT INTO open_channel_htlcs (
+		nodeid
+	,	peerid
+	,	funding_tx_id
+	,	funding_tx_outnum
+	,	forward_amt_msat
+	,	original_amt_msat
+	,   incoming_amt_msat
+	,   forward_time
+	) VALUES ($1, $2, $3, $4, $5, $6, $7)
+	`,
+		htlc.NodeId,
+		htlc.PeerId,
+		htlc.ChannelPoint.Hash[:],
+		htlc.ChannelPoint.Index,
+		int64(htlc.ForwardAmountMsat),
+		int64(htlc.OriginalAmountMsat),
+		int64(htlc.IncomingAmountMsat),
+		htlc.ForwardTime.UnixNano(),
+	)
+	return err
+}

--- a/postgresql/migrations/000016_open_channel_htlc.down.sql
+++ b/postgresql/migrations/000016_open_channel_htlc.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE public.open_channel_htlcs;

--- a/postgresql/migrations/000016_open_channel_htlc.up.sql
+++ b/postgresql/migrations/000016_open_channel_htlc.up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE public.open_channel_htlcs (
+	nodeid bytea NOT NULL,
+    peerid bytea NOT NULL,
+	funding_tx_id bytea NOT NULL,
+	funding_tx_outnum bigint NOT NULL,
+    forward_amt_msat bigint NOT NULL,
+    original_amt_msat bigint NOT NULL,
+    forward_time bigint NOT NULL
+);


### PR DESCRIPTION
Adding a table that will contain information about which HTLCs are used for which channel open.
This is useful for the revenue report in an upcoming pull request.

Unfortunately I could not find a good identifier for the htlc that is equivalent in the htlc interceptor hook and the listforwards call. So matching the htlcs used for a channel open to the htlcs persisted in the history requires some logic.