### PR TITLE
min/max payment size in fee params in lsps2

### DIFF
--- a/common/opening_store.go
+++ b/common/opening_store.go
@@ -3,17 +3,13 @@ package common
 import "time"
 
 type OpeningFeeParamsSetting struct {
-	Validity time.Duration
-	Params   *OpeningFeeParams
-}
-
-type OpeningFeeParams struct {
-	MinFeeMsat           uint64 `json:"min_msat,string"`
-	Proportional         uint32 `json:"proportional"`
-	ValidUntil           string `json:"valid_until"`
-	MinLifetime          uint32 `json:"max_idle_time"`
-	MaxClientToSelfDelay uint32 `json:"max_client_to_self_delay"`
-	Promise              string `json:"promise"`
+	Validity             time.Duration
+	MinFeeMsat           uint64
+	Proportional         uint32
+	MinLifetime          uint32
+	MaxClientToSelfDelay uint32
+	MinPaymentSizeMsat   uint64
+	MaxPaymentSizeMsat   uint64
 }
 
 type OpeningStore interface {

--- a/config/config.go
+++ b/config/config.go
@@ -84,14 +84,6 @@ type NodeConfig struct {
 	// peer is offline. Defaults to 1m.
 	NotificationTimeout string `json:"notificationTimeout,string"`
 
-	// The minimum payment size accepted in LSPS2 forwards that need a channel
-	// open.
-	MinPaymentSizeMsat uint64 `json:"minPaymentSizeMsat,string"`
-
-	// The maximum payment size accepted in LSPS2 forwards that need a channel
-	// open.
-	MaxPaymentSizeMsat uint64 `json:"maxPaymentSizeMsat,string"`
-
 	// Set this field to connect to an LND node.
 	Lnd *LndConfig `json:"lnd,omitempty"`
 

--- a/itest/lsps2_buy_test.go
+++ b/itest/lsps2_buy_test.go
@@ -48,13 +48,13 @@ func testLsps2Buy(p *testParams) {
 		ValidUntil           string `json:"valid_until"`
 		MinLifetime          uint32 `json:"min_lifetime"`
 		MaxClientToSelfDelay uint32 `json:"max_client_to_self_delay"`
+		MinPaymentSizeMsat   uint64 `json:"min_payment_size_msat,string"`
+		MaxPaymentSizeMsat   uint64 `json:"max_payment_size_msat,string"`
 		Promise              string `json:"promise"`
 	}
 	data := new(struct {
 		Result struct {
-			Menu       []params `json:"opening_fee_params_menu"`
-			MinPayment uint64   `json:"min_payment_size_msat,string"`
-			MaxPayment uint64   `json:"max_payment_size_msat,string"`
+			Menu []params `json:"opening_fee_params_menu"`
 		} `json:"result"`
 	})
 	err := json.Unmarshal(resp.Data[:], &data)

--- a/itest/lsps2_get_info_test.go
+++ b/itest/lsps2_get_info_test.go
@@ -62,12 +62,16 @@ func testLsps2GetInfo(p *testParams) {
 		ValidUntil           string `json:"valid_until"`
 		MinLifetime          uint32 `json:"min_lifetime"`
 		MaxClientToSelfDelay uint32 `json:"max_client_to_self_delay"`
+		MinPaymentSizeMsat   uint64 `json:"min_payment_size_msat,string"`
+		MaxPaymentSizeMsat   uint64 `json:"max_payment_size_msat,string"`
 		Promise              string `json:"promise"`
 	}{}
 	err = json.Unmarshal(result["opening_fee_params_menu"], &menu)
 	lntest.CheckError(p.t, err)
 
-	assert.Len(p.t, menu, 2)
+	if !assert.Len(p.t, menu, 2) {
+		return
+	}
 	assert.Equal(p.t, uint64(2000000), menu[0].MinFeeMsat)
 	assert.Equal(p.t, uint64(3000000), menu[1].MinFeeMsat)
 }

--- a/lsps2/mocks.go
+++ b/lsps2/mocks.go
@@ -31,29 +31,31 @@ func (m *mockNodesService) GetNodes() []*common.Node {
 }
 
 type mockOpeningService struct {
-	menu                     []*common.OpeningFeeParams
+	menu                     []*OpeningFeeParams
 	err                      error
 	invalid                  bool
 	isCurrentChainFeeCheaper bool
 }
 
 func (m *mockOpeningService) GetFeeParamsMenu(
+	ctx context.Context,
 	token string,
 	privateKey *btcec.PrivateKey,
-) ([]*common.OpeningFeeParams, error) {
+) ([]*OpeningFeeParams, error) {
 	return m.menu, m.err
 }
 
 func (m *mockOpeningService) ValidateOpeningFeeParams(
-	params *common.OpeningFeeParams,
+	params *OpeningFeeParams,
 	publicKey *btcec.PublicKey,
 ) bool {
 	return !m.invalid
 }
 
 func (m *mockOpeningService) IsCurrentChainFeeCheaper(
+	ctx context.Context,
 	token string,
-	params *common.OpeningFeeParams,
+	params *OpeningFeeParams,
 ) bool {
 	return m.isCurrentChainFeeCheaper
 }
@@ -95,6 +97,9 @@ func (s *mockLsps2Store) SavePromises(ctx context.Context, req *SavePromises) er
 
 func (s *mockLsps2Store) RemoveUnusedExpired(ctx context.Context, before time.Time) error {
 	return nil
+}
+func (s *mockLsps2Store) GetFeeParamsSettings(ctx context.Context, token string) ([]*OpeningFeeParamsSetting, error) {
+	return nil, ErrNotImplemented
 }
 
 type mockHistoryStore struct{}

--- a/lsps2/server_test.go
+++ b/lsps2/server_test.go
@@ -16,9 +16,7 @@ var token = "blah"
 var node = func() *common.Node {
 	return &common.Node{
 		NodeConfig: &config.NodeConfig{
-			MinPaymentSizeMsat: 1000,
-			MaxPaymentSizeMsat: 10000,
-			TimeLockDelta:      143,
+			TimeLockDelta: 143,
 		},
 	}
 }
@@ -58,7 +56,7 @@ func Test_GetInfo_InvalidToken(t *testing.T) {
 func Test_GetInfo_EmptyMenu(t *testing.T) {
 	node := node()
 	n := &mockNodesService{node: node}
-	o := &mockOpeningService{menu: []*common.OpeningFeeParams{}}
+	o := &mockOpeningService{menu: []*OpeningFeeParams{}}
 	st := &mockLsps2Store{}
 	s := NewLsps2Server(o, n, node, st)
 	resp, err := s.GetInfo(context.Background(), &GetInfoRequest{
@@ -68,28 +66,30 @@ func Test_GetInfo_EmptyMenu(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, []*OpeningFeeParams{}, resp.OpeningFeeParamsMenu)
-	assert.Equal(t, node.NodeConfig.MinPaymentSizeMsat, resp.MinPaymentSizeMsat)
-	assert.Equal(t, node.NodeConfig.MaxPaymentSizeMsat, resp.MaxPaymentSizeMsat)
 }
 
 func Test_GetInfo_PopulatedMenu_Ordered(t *testing.T) {
 	node := node()
 	n := &mockNodesService{node: node}
-	o := &mockOpeningService{menu: []*common.OpeningFeeParams{
+	o := &mockOpeningService{menu: []*OpeningFeeParams{
 		{
 			MinFeeMsat:           1,
 			Proportional:         2,
 			ValidUntil:           "a",
 			MinLifetime:          3,
 			MaxClientToSelfDelay: 4,
+			MinPaymentSizeMsat:   5,
+			MaxPaymentSizeMsat:   6,
 			Promise:              "b",
 		},
 		{
-			MinFeeMsat:           5,
-			Proportional:         6,
+			MinFeeMsat:           7,
+			Proportional:         8,
 			ValidUntil:           "c",
-			MinLifetime:          7,
-			MaxClientToSelfDelay: 8,
+			MinLifetime:          9,
+			MaxClientToSelfDelay: 10,
+			MinPaymentSizeMsat:   11,
+			MaxPaymentSizeMsat:   12,
 			Promise:              "d",
 		},
 	}}
@@ -108,17 +108,18 @@ func Test_GetInfo_PopulatedMenu_Ordered(t *testing.T) {
 	assert.Equal(t, "a", resp.OpeningFeeParamsMenu[0].ValidUntil)
 	assert.Equal(t, uint32(3), resp.OpeningFeeParamsMenu[0].MinLifetime)
 	assert.Equal(t, uint32(4), resp.OpeningFeeParamsMenu[0].MaxClientToSelfDelay)
+	assert.Equal(t, uint64(5), resp.OpeningFeeParamsMenu[0].MinPaymentSizeMsat)
+	assert.Equal(t, uint64(6), resp.OpeningFeeParamsMenu[0].MaxPaymentSizeMsat)
 	assert.Equal(t, "b", resp.OpeningFeeParamsMenu[0].Promise)
 
-	assert.Equal(t, uint64(5), resp.OpeningFeeParamsMenu[1].MinFeeMsat)
-	assert.Equal(t, uint32(6), resp.OpeningFeeParamsMenu[1].Proportional)
+	assert.Equal(t, uint64(7), resp.OpeningFeeParamsMenu[1].MinFeeMsat)
+	assert.Equal(t, uint32(8), resp.OpeningFeeParamsMenu[1].Proportional)
 	assert.Equal(t, "c", resp.OpeningFeeParamsMenu[1].ValidUntil)
-	assert.Equal(t, uint32(7), resp.OpeningFeeParamsMenu[1].MinLifetime)
-	assert.Equal(t, uint32(8), resp.OpeningFeeParamsMenu[1].MaxClientToSelfDelay)
+	assert.Equal(t, uint32(9), resp.OpeningFeeParamsMenu[1].MinLifetime)
+	assert.Equal(t, uint32(10), resp.OpeningFeeParamsMenu[1].MaxClientToSelfDelay)
+	assert.Equal(t, uint64(11), resp.OpeningFeeParamsMenu[1].MinPaymentSizeMsat)
+	assert.Equal(t, uint64(12), resp.OpeningFeeParamsMenu[1].MaxPaymentSizeMsat)
 	assert.Equal(t, "d", resp.OpeningFeeParamsMenu[1].Promise)
-
-	assert.Equal(t, node.NodeConfig.MinPaymentSizeMsat, resp.MinPaymentSizeMsat)
-	assert.Equal(t, node.NodeConfig.MaxPaymentSizeMsat, resp.MaxPaymentSizeMsat)
 }
 
 func Test_Buy_UnsupportedVersion(t *testing.T) {
@@ -151,6 +152,8 @@ func Test_Buy_InvalidFeeParams(t *testing.T) {
 			ValidUntil:           "2023-08-18T13:39:00.000Z",
 			MinLifetime:          3,
 			MaxClientToSelfDelay: 4,
+			MinPaymentSizeMsat:   5,
+			MaxPaymentSizeMsat:   6,
 			Promise:              "fake",
 		},
 	})
@@ -241,6 +244,8 @@ func Test_Buy_PaymentSize(t *testing.T) {
 						ValidUntil:           "2023-08-18T13:39:00.000Z",
 						MinLifetime:          3,
 						MaxClientToSelfDelay: 4,
+						MinPaymentSizeMsat:   1000,
+						MaxPaymentSizeMsat:   10000,
 						Promise:              "fake",
 					},
 					PaymentSizeMsat: &c.paymentSize,
@@ -276,6 +281,8 @@ func Test_Buy_Registered(t *testing.T) {
 			ValidUntil:           "2023-08-18T13:39:00.000Z",
 			MinLifetime:          3,
 			MaxClientToSelfDelay: 4,
+			MinPaymentSizeMsat:   1000,
+			MaxPaymentSizeMsat:   10000,
 			Promise:              "fake",
 		},
 		PaymentSizeMsat: &paymentSize,
@@ -292,6 +299,8 @@ func Test_Buy_Registered(t *testing.T) {
 	assert.Equal(t, "2023-08-18T13:39:00.000Z", st.req.OpeningFeeParams.ValidUntil)
 	assert.Equal(t, uint32(3), st.req.OpeningFeeParams.MinLifetime)
 	assert.Equal(t, uint32(4), st.req.OpeningFeeParams.MaxClientToSelfDelay)
+	assert.Equal(t, uint64(1000), st.req.OpeningFeeParams.MinPaymentSizeMsat)
+	assert.Equal(t, uint64(10000), st.req.OpeningFeeParams.MaxPaymentSizeMsat)
 	assert.Equal(t, "fake", st.req.OpeningFeeParams.Promise)
 
 	assert.Equal(t, st.req.Scid.ToString(), resp.JitChannelScid)

--- a/lsps2/store.go
+++ b/lsps2/store.go
@@ -7,14 +7,13 @@ import (
 	"time"
 
 	"github.com/GoWebProd/uuid7"
-	"github.com/breez/lspd/common"
 	"github.com/breez/lspd/lightning"
 	"github.com/breez/lspd/lsps0"
 	"github.com/btcsuite/btcd/wire"
 )
 
 type SavePromises struct {
-	Menu  []*common.OpeningFeeParams
+	Menu  []*OpeningFeeParams
 	Token string
 }
 
@@ -22,7 +21,7 @@ type RegisterBuy struct {
 	LspId            string
 	PeerId           string
 	Scid             lightning.ShortChannelID
-	OpeningFeeParams common.OpeningFeeParams
+	OpeningFeeParams OpeningFeeParams
 	PaymentSizeMsat  *uint64
 	Mode             OpeningMode
 }
@@ -33,11 +32,21 @@ type BuyRegistration struct {
 	PeerId           string // TODO: Make peerId in the registration a byte array.
 	Token            string
 	Scid             lightning.ShortChannelID
-	OpeningFeeParams common.OpeningFeeParams
+	OpeningFeeParams OpeningFeeParams
 	PaymentSizeMsat  *uint64
 	Mode             OpeningMode
 	ChannelPoint     *wire.OutPoint
 	IsComplete       bool
+}
+
+type OpeningFeeParamsSetting struct {
+	Validity             time.Duration
+	MinFeeMsat           uint64
+	Proportional         uint32
+	MinLifetime          uint32
+	MaxClientToSelfDelay uint32
+	MinPaymentSizeMsat   uint64
+	MaxPaymentSizeMsat   uint64
 }
 
 func (b *BuyRegistration) IsExpired() bool {
@@ -65,6 +74,7 @@ var ErrScidExists = errors.New("scid exists")
 var ErrNotFound = errors.New("not found")
 
 type Lsps2Store interface {
+	GetFeeParamsSettings(ctx context.Context, token string) ([]*OpeningFeeParamsSetting, error)
 	SavePromises(ctx context.Context, req *SavePromises) error
 	RegisterBuy(ctx context.Context, req *RegisterBuy) error
 	GetBuyRegistration(ctx context.Context, scid lightning.ShortChannelID) (*BuyRegistration, error)

--- a/postgresql/intercept_store.go
+++ b/postgresql/intercept_store.go
@@ -14,6 +14,11 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
+type extendedParams struct {
+	Token  string                  `json:"token"`
+	Params common.OpeningFeeParams `json:"fees_params"`
+}
+
 type PostgresInterceptStore struct {
 	pool *pgxpool.Pool
 }

--- a/postgresql/migrations/000017_lsps2_min_max_payment_size.down.sql
+++ b/postgresql/migrations/000017_lsps2_min_max_payment_size.down.sql
@@ -1,0 +1,26 @@
+ALTER TABLE lsps2.buy_registrations
+DROP COLUMN params_min_payment_size_msat,
+DROP COLUMN params_max_payment_size_msat;
+
+ALTER TABLE public.new_channel_params
+ADD COLUMN params jsonb NULL;
+
+UPDATE public.new_channel_params a
+SET params = to_jsonb(c)
+FROM (
+    SELECT b.min_fee_msat::varchar AS min_msat
+    ,      b.proportional
+    ,      b.min_lifetime AS max_idle_time
+    ,      b.max_client_to_self_delay
+    FROM public.new_channel_params b
+    WHERE a.token = b.token AND a.validity = b.validity
+) c;
+
+ALTER TABLE public.new_channel_params
+DROP COLUMN min_fee_msat,
+DROP COLUMN proportional,
+DROP COLUMN min_lifetime,
+DROP COLUMN max_client_to_self_delay,
+DROP COLUMN min_payment_size_msat,
+DROP COLUMN max_payment_size_msat
+ALTER COLUMN params SET NOT NULL;

--- a/postgresql/migrations/000017_lsps2_min_max_payment_size.up.sql
+++ b/postgresql/migrations/000017_lsps2_min_max_payment_size.up.sql
@@ -1,0 +1,35 @@
+ALTER TABLE lsps2.buy_registrations 
+ADD COLUMN params_min_payment_size_msat bigint NULL,
+ADD COLUMN params_max_payment_size_msat bigint NULL;
+
+UPDATE lsps2.buy_registrations
+SET params_min_payment_size_msat = 0, params_max_payment_size_msat = 0;
+
+ALTER TABLE lsps2.buy_registrations
+ALTER COLUMN params_min_payment_size_msat SET NOT NULL,
+ALTER COLUMN params_max_payment_size_msat SET NOT NULL;
+
+ALTER TABLE public.new_channel_params
+ADD COLUMN min_fee_msat bigint NULL,
+ADD COLUMN proportional bigint NULL,
+ADD COLUMN min_lifetime bigint NULL,
+ADD COLUMN max_client_to_self_delay bigint NULL,
+ADD COLUMN min_payment_size_msat bigint NULL,
+ADD COLUMN max_payment_size_msat bigint NULL;
+
+UPDATE public.new_channel_params
+SET min_fee_msat = (params::json->>'min_msat')::bigint
+,   proportional = (params::json->>'proportional')::bigint
+,   min_lifetime = (params::json->>'max_idle_time')::bigint
+,   max_client_to_self_delay = (params::json->>'max_client_to_self_delay')::bigint
+,   min_payment_size_msat = 1000
+,   max_payment_size_msat = 4000000000;
+
+ALTER TABLE public.new_channel_params
+ALTER COLUMN min_fee_msat SET NOT NULL,
+ALTER COLUMN proportional SET NOT NULL,
+ALTER COLUMN min_lifetime SET NOT NULL,
+ALTER COLUMN max_client_to_self_delay SET NOT NULL,
+ALTER COLUMN min_payment_size_msat SET NOT NULL,
+ALTER COLUMN max_payment_size_msat SET NOT NULL,
+DROP COLUMN params;

--- a/postgresql/opening_store.go
+++ b/postgresql/opening_store.go
@@ -2,18 +2,12 @@ package postgresql
 
 import (
 	"context"
-	"encoding/json"
 	"log"
 	"time"
 
 	"github.com/breez/lspd/common"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
-
-type extendedParams struct {
-	Token  string                  `json:"token"`
-	Params common.OpeningFeeParams `json:"fees_params"`
-}
 
 type PostgresOpeningStore struct {
 	pool *pgxpool.Pool
@@ -25,7 +19,14 @@ func NewPostgresOpeningStore(pool *pgxpool.Pool) *PostgresOpeningStore {
 
 func (s *PostgresOpeningStore) GetFeeParamsSettings(token string) ([]*common.OpeningFeeParamsSetting, error) {
 	rows, err := s.pool.Query(context.Background(),
-		`SELECT validity, params FROM new_channel_params WHERE token=$1 AND validity>0`, token)
+		`SELECT validity
+		 ,      min_fee_msat 
+		 ,      proportional
+		 ,      min_lifetime
+		 ,      max_client_to_self_delay
+		 ,      min_payment_size_msat
+		 ,      max_payment_size_msat
+		 FROM new_channel_params WHERE token=$1 AND validity>0`, token)
 	if err != nil {
 		log.Printf("GetFeeParamsSettings(%v) error: %v", token, err)
 		return nil, err
@@ -35,23 +36,34 @@ func (s *PostgresOpeningStore) GetFeeParamsSettings(token string) ([]*common.Ope
 	var settings []*common.OpeningFeeParamsSetting
 	for rows.Next() {
 		var validity int64
-		var param string
-		err = rows.Scan(&validity, &param)
+		var min_fee_msat int64
+		var proportional uint32
+		var min_lifetime uint32
+		var max_client_to_self_delay uint32
+		var min_payment_size_msat int64
+		var max_payment_size_msat int64
+		err = rows.Scan(
+			&validity,
+			&min_fee_msat,
+			&proportional,
+			&min_lifetime,
+			&max_client_to_self_delay,
+			&min_payment_size_msat,
+			&max_payment_size_msat,
+		)
 		if err != nil {
-			return nil, err
-		}
-
-		var params *common.OpeningFeeParams
-		err := json.Unmarshal([]byte(param), &params)
-		if err != nil {
-			log.Printf("Failed to unmarshal fee param '%v': %v", param, err)
 			return nil, err
 		}
 
 		duration := time.Second * time.Duration(validity)
 		settings = append(settings, &common.OpeningFeeParamsSetting{
-			Validity: duration,
-			Params:   params,
+			Validity:             duration,
+			MinFeeMsat:           uint64(min_fee_msat),
+			Proportional:         proportional,
+			MinLifetime:          min_lifetime,
+			MaxClientToSelfDelay: max_client_to_self_delay,
+			MinPaymentSizeMsat:   uint64(min_payment_size_msat),
+			MaxPaymentSizeMsat:   uint64(max_payment_size_msat),
 		})
 	}
 


### PR DESCRIPTION
This change splits the logic for fee params generation between lsps2 and the grpc protocol, because it adds two fields to the opening fee params. These fields would otherwise not be able to be added without breaking existing clients, or having to trust clients to pass the right parameters. Making these parameters available only in lsps2 gives a clear upgrade path.

The fee params settings for lsps2 are now stored in their own table, specifically for lsps2.

Closes https://github.com/breez/lspd/issues/186