### PR TITLE
Fix Insert Open Channel HTLC SQL Statement

### DIFF
--- a/postgresql/history_store.go
+++ b/postgresql/history_store.go
@@ -358,7 +358,7 @@ func (s *HistoryStore) AddOpenChannelHtlc(ctx context.Context, htlc *history.Ope
 	,	original_amt_msat
 	,   incoming_amt_msat
 	,   forward_time
-	) VALUES ($1, $2, $3, $4, $5, $6, $7)
+	) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 	`,
 		htlc.NodeId,
 		htlc.PeerId,


### PR DESCRIPTION
Currently the htlc's `forward_time` was probably not getting inserted, as it was missing a field in the SQL statement.