### PR TITLE
fix missing column in open_channel_htlc

### DIFF
--- a/interceptor/intercept_handler.go
+++ b/interceptor/intercept_handler.go
@@ -271,11 +271,12 @@ func (i *Interceptor) Intercept(req common.InterceptRequest) common.InterceptRes
 					// Don't break here, this is not critical.
 					log.Printf(
 						"paymentHash: %s, failed to insert htlc used for channel open in history store: channel: %v,"+
-							" original amount: %v, forward amount: %v",
+							" original amount: %v, forward amount: %v, error: %v",
 						reqPaymentHashStr,
 						channelPoint.String(),
 						req.OutgoingAmountMsat,
 						amt,
+						err,
 					)
 				}
 

--- a/postgresql/migrations/000017_open_channel_htlc_incoming.down.sql
+++ b/postgresql/migrations/000017_open_channel_htlc_incoming.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.open_channel_htlcs
+DROP COLUMN incoming_amt_msat;

--- a/postgresql/migrations/000017_open_channel_htlc_incoming.up.sql
+++ b/postgresql/migrations/000017_open_channel_htlc_incoming.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.open_channel_htlcs
+ADD COLUMN incoming_amt_msat bigint NOT NULL;


### PR DESCRIPTION
https://github.com/breez/lspd/pull/189 added inserts for htlcs used for channel opens. The database migration was missing a column though, so inserts failed. This PR adds that column.