### PR TITLE
disable cgo in build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,15 +5,15 @@ release-all: release-lspd release-plugin release-cli
 
 release-lspd:
 	go get $(PKG)/cmd/lspd
-	go build -v -trimpath -o lspd -ldflags "-s -w -X $(PKG)/build.tag=$(TAG)" $(PKG)/cmd/lspd
+	CGO_ENABLED=0 go build -v -trimpath -o lspd -ldflags "-s -w -X $(PKG)/build.tag=$(TAG)" $(PKG)/cmd/lspd
 
 release-plugin:
 	go get $(PKG)/cmd/lspd_cln_plugin
-	go build -v -trimpath -o lspd_cln_plugin -ldflags="-s -w -X $(PKG)/build.tag=$(TAG)" $(PKG)/cmd/lspd_cln_plugin
+	CGO_ENABLED=0 go build -v -trimpath -o lspd_cln_plugin -ldflags="-s -w -X $(PKG)/build.tag=$(TAG)" $(PKG)/cmd/lspd_cln_plugin
 
 release-cli:
 	go get $(PKG)/cmd/lspd_revenue_cli
-	go build -v -trimpath -o lspd_revenue_cli -ldflags="-s -w -X $(PKG)/build.tag=$(TAG)" $(PKG)/cmd/lspd_revenue_cli
+	CGO_ENABLED=0 go build -v -trimpath -o lspd_revenue_cli -ldflags="-s -w -X $(PKG)/build.tag=$(TAG)" $(PKG)/cmd/lspd_revenue_cli
 
 clean:
 	rm -f lspd


### PR DESCRIPTION
Disable cgo in the release builds. It is not necessary and causes glibc issues on some platforms.