### PR TITLE
lnd forward starttime filter is in seconds

### DIFF
--- a/lnd/forwards_sync.go
+++ b/lnd/forwards_sync.go
@@ -59,7 +59,7 @@ func (s *ForwardSync) forwardsSynchronizeOnce(ctx context.Context) {
 
 	for {
 		forwardHistory, err := s.client.client.ForwardingHistory(context.Background(), &lnrpc.ForwardingHistoryRequest{
-			StartTime:    startTime,
+			StartTime:    startTime / 1_000_000_000,
 			NumMaxEvents: 10000,
 		})
 		if err != nil {
@@ -84,7 +84,7 @@ func (s *ForwardSync) forwardsSynchronizeOnce(ctx context.Context) {
 			}
 			startTime = f.TimestampNs
 		}
-		s.store.InsertForwards(ctx, forwards, s.nodeid)
+		err = s.store.InsertForwards(ctx, forwards, s.nodeid)
 		if err != nil {
 			log.Printf("forwardsSynchronizeOnce(%x) - store.InsertForwards() error: %v", s.nodeid, err)
 			return


### PR DESCRIPTION
The start time filter was set in nanoseconds, causing every subsequent run not to fetch any forwards, so forward sync only synced the initial batch of 10000 forwards.