### PR TITLE
Improve cln plugin robustness

### DIFF
--- a/cln/cln_interceptor.go
+++ b/cln/cln_interceptor.go
@@ -140,6 +140,12 @@ func (i *ClnHtlcInterceptor) intercept() error {
 					return
 				}
 
+				if request.Onion == nil || request.Onion.ShortChannelId == "" {
+					interceptorClient.Send(i.defaultResolution(request))
+					i.doneWg.Done()
+					return
+				}
+
 				scid, err := lightning.NewShortChannelIDFromString(request.Onion.ShortChannelId)
 				if err != nil {
 					interceptorClient.Send(i.defaultResolution(request))

--- a/cln_plugin/cln_plugin.go
+++ b/cln_plugin/cln_plugin.go
@@ -91,6 +91,7 @@ func (c *ClnPlugin) Start() error {
 	<-c.ctx.Done()
 	<-c.serverStopped
 
+	log.Printf("lspd cln_plugin stopped.")
 	return c.ctx.Err()
 }
 

--- a/cln_plugin/cln_plugin.go
+++ b/cln_plugin/cln_plugin.go
@@ -571,26 +571,22 @@ func (c *ClnPlugin) setupClnLogging() {
 		// everytime we get a new message, log it through cln
 		scanner := bufio.NewScanner(in)
 		for {
-			select {
-			case <-c.ctx.Done():
-				return
-			default:
-				if !scanner.Scan() {
-					if err := scanner.Err(); err != nil {
-						errLogger.Printf("Log input stream died: %v", err)
-						<-time.After(time.Second)
-						continue
-					}
+			if !scanner.Scan() {
+				if err := scanner.Err(); err != nil {
+					errLogger.Printf("Log input stream died: %v", err)
+					<-time.After(time.Second)
 				}
 
-				for _, line := range strings.Split(scanner.Text(), "\n") {
-					err := c.writer.Write(&LogNotification{
-						Level:   "info",
-						Message: line,
-					})
-					if err != nil {
-						errLogger.Printf("Failed to write log '%s' to cln, error: %v", line, err)
-					}
+				continue
+			}
+
+			for _, line := range strings.Split(scanner.Text(), "\n") {
+				err := c.writer.Write(&LogNotification{
+					Level:   "info",
+					Message: line,
+				})
+				if err != nil {
+					errLogger.Printf("Failed to write log '%s' to cln, error: %v", line, err)
 				}
 			}
 		}

--- a/cln_plugin/cln_plugin.go
+++ b/cln_plugin/cln_plugin.go
@@ -560,8 +560,10 @@ func (c *ClnPlugin) sendToCln(msg interface{}) error {
 	if err != nil {
 		log.Printf("Failed to send message to cln: %v", err)
 		c.Stop()
+		return fmt.Errorf("failed to send message to cln: %w", err)
 	}
-	return fmt.Errorf("failed to send message to cln: %w", err)
+
+	return nil
 }
 
 func (c *ClnPlugin) setupClnLogging() {
@@ -574,7 +576,7 @@ func (c *ClnPlugin) setupClnLogging() {
 		for {
 			if !scanner.Scan() {
 				if err := scanner.Err(); err != nil {
-					errLogger.Printf("Log input stream died: %v", err)
+					errLogger.Printf("Log input stream died: %s", err.Error())
 					<-time.After(time.Second)
 				}
 
@@ -584,7 +586,7 @@ func (c *ClnPlugin) setupClnLogging() {
 			for _, line := range strings.Split(scanner.Text(), "\n") {
 				err := c.log("info", line)
 				if err != nil {
-					errLogger.Printf("Failed to write log '%s' to cln, error: %v", line, err)
+					errLogger.Printf("Failed to write log '%s' to cln, error: %s", line, err.Error())
 				}
 			}
 		}

--- a/cln_plugin/reader.go
+++ b/cln_plugin/reader.go
@@ -1,0 +1,104 @@
+package cln_plugin
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sync"
+)
+
+const (
+	maxIntakeBuffer = 500 * 1024 * 1023
+)
+
+type reader struct {
+	in       io.ReadCloser
+	mtx      sync.Mutex
+	scanner  *bufio.Scanner
+	buffered []*Request
+}
+
+func newReader(in io.ReadCloser) *reader {
+	scanner := bufio.NewScanner(in)
+	buf := make([]byte, 1024)
+	scanner.Buffer(buf, maxIntakeBuffer)
+
+	// cln messages are split by a double newline.
+	scanner.Split(scanDoubleNewline)
+	return &reader{
+		in:      in,
+		scanner: scanner,
+	}
+}
+
+func (r *reader) Close() error {
+	return r.in.Close()
+}
+
+func (r *reader) Next() (*Request, error) {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+
+	// If there's buffered requests, take that
+	if req := r.takeFromBuffer(); req != nil {
+		return req, nil
+	}
+
+	// Advance the reader
+	if !r.scanner.Scan() {
+		if r.scanner.Err() != nil {
+			return nil, r.scanner.Err()
+		} else {
+			return nil, io.EOF
+		}
+	}
+
+	msg := r.scanner.Bytes()
+	if len(msg) == 0 {
+		return nil, fmt.Errorf("got invalid zero length message")
+	}
+
+	// Handle request batches.
+	if msg[0] == '[' {
+		err := json.Unmarshal(msg, &r.buffered)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal request batch: %w", err)
+		}
+
+		return r.takeFromBuffer(), nil
+	}
+
+	// Parse the received buffer into a request object.
+	var request Request
+	err := json.Unmarshal(msg, &request)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal request: %w", err)
+	}
+	return &request, nil
+}
+
+func (r *reader) takeFromBuffer() *Request {
+	if len(r.buffered) > 0 {
+		req := r.buffered[0]
+		r.buffered = r.buffered[1:]
+		return req
+	}
+
+	return nil
+}
+
+// Helper method for the bufio scanner to split messages on double newlines.
+func scanDoubleNewline(
+	data []byte,
+	atEOF bool,
+) (advance int, token []byte, err error) {
+	for i := 0; i < len(data); i++ {
+		if data[i] == '\n' && (i+1) < len(data) && data[i+1] == '\n' {
+			return i + 2, data[:i], nil
+		}
+	}
+	// this trashes anything left over in
+	// the buffer if we're at EOF, with no /n/n present
+	return 0, nil, nil
+}

--- a/cln_plugin/server.go
+++ b/cln_plugin/server.go
@@ -105,6 +105,10 @@ func (s *server) Start(address string, subscriberTimeout time.Duration) error {
 		s.startError <- err
 		return err
 	}
+	go func() {
+		<-s.ctx.Done()
+		s.grpcServer.Stop()
+	}()
 	close(s.started)
 	err = s.grpcServer.Serve(lis)
 	return err
@@ -154,12 +158,8 @@ func (s *server) WaitStarted() error {
 
 // Stops all work from the grpc server immediately.
 func (s *server) Stop() {
-	s.mtx.Lock()
-	defer s.mtx.Unlock()
 	log.Printf("Server Stop() called.")
 	s.cancel()
-	s.grpcServer.Stop()
-	log.Printf("Server stopped.")
 }
 
 // Grpc method that is called when a new client subscribes. There can only be

--- a/cln_plugin/writer.go
+++ b/cln_plugin/writer.go
@@ -1,0 +1,37 @@
+package cln_plugin
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sync"
+)
+
+type writer struct {
+	mtx sync.Mutex
+	out io.Writer
+}
+
+func newWriter(out io.Writer) *writer {
+	return &writer{
+		out: out,
+	}
+}
+
+func (w *writer) Write(msg interface{}) error {
+	w.mtx.Lock()
+	defer w.mtx.Unlock()
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("failed to marshal to json: %w", err)
+	}
+
+	data = append(data, TwoNewLines...)
+	_, err = w.out.Write(data)
+	if err != nil {
+		return fmt.Errorf("failed to write to rpc socket: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/lspd_cln_plugin/main.go
+++ b/cmd/lspd_cln_plugin/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	plugin := cln_plugin.NewClnPlugin(os.Stdin, os.Stdout)
+	plugin := cln_plugin.NewClnPlugin(os.Stdin, os.Stdout, os.Stderr)
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
 	go func() {

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	go.starlark.net v0.0.0-20231101134539-556fd59b42f6
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
 	golang.org/x/sync v0.3.0
+	golang.org/x/sys v0.18.0
 	google.golang.org/grpc v1.59.0
 )
 
@@ -188,7 +189,6 @@ require (
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.17.0 // indirect
 	golang.org/x/crypto v0.21.0 // indirect
-	golang.org/x/sys v0.18.0 // indirect
 	golang.org/x/term v0.18.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.3.0 // indirect


### PR DESCRIPTION
Main features
- whenever lightningd is gone or unreachable, the plugin will exit
- whenever the grpc server stops, the plugin will exit
- if the plugin can't log to cln, it will log to stderr
- the plugin will periodically log the number of inflight htlcs it is managing
- the cln interceptor will short-circuit htlcs that aren't forwards (the local node is the recipient)
- the plugin grpc server will reuse the port, even if it's already in use, to ensure it's always able to grab the port