### PR TITLE
Prettify some logs

### DIFF
--- a/common/combined_handler.go
+++ b/common/combined_handler.go
@@ -15,7 +15,12 @@ func NewCombinedHandler(handlers ...InterceptHandler) *CombinedHandler {
 func (c *CombinedHandler) Intercept(req InterceptRequest) InterceptResult {
 	for i, handler := range c.handlers {
 		res := handler.Intercept(req)
-		log.Printf("Intercept %+v. Interceptor %d returns %+v", req, i, res)
+		log.Printf(
+			"Intercept {%s}. Interceptor %d returns {%s}",
+			req.String(),
+			i,
+			res.String(),
+		)
 		if res.Action != INTERCEPT_RESUME {
 			return res
 		}

--- a/common/intercept_handler.go
+++ b/common/intercept_handler.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/breez/lspd/lightning"
 	"github.com/btcsuite/btcd/wire"
@@ -47,6 +48,19 @@ func (r *InterceptRequest) HtlcId() string {
 	return r.Identifier
 }
 
+func (r *InterceptRequest) String() string {
+	return fmt.Sprintf(
+		"id: %s, paymenthash: %x, scid: %s, amt_in: %d, amt_out: %d, expiry_in: %d, expiry_out: %d",
+		r.Identifier,
+		r.PaymentHash,
+		r.Scid.ToString(),
+		r.IncomingAmountMsat,
+		r.OutgoingAmountMsat,
+		r.IncomingExpiry,
+		r.OutgoingExpiry,
+	)
+}
+
 type InterceptResult struct {
 	Action             InterceptAction
 	FailureCode        InterceptFailureCode
@@ -58,6 +72,29 @@ type InterceptResult struct {
 	Scid               lightning.ShortChannelID
 	PaymentSecret      []byte
 	UseLegacyOnionBlob bool
+}
+
+func (r *InterceptResult) String() string {
+	var feeMsat string
+	if r.FeeMsat != nil {
+		feeMsat = strconv.FormatUint(*r.FeeMsat, 10)
+	}
+	var cp string
+	if r.ChannelPoint != nil {
+		cp = r.ChannelPoint.String()
+	}
+	return fmt.Sprintf(
+		"action: %v, code: %v, destination: %x, amt: %d, fee: %s, total_amt: %d, channelpoint: %s, scid: %s, use_legacy_blob: %t",
+		r.Action,
+		r.FailureCode,
+		r.Destination,
+		r.AmountMsat,
+		feeMsat,
+		r.TotalAmountMsat,
+		cp,
+		r.Scid.ToString(),
+		r.UseLegacyOnionBlob,
+	)
 }
 
 type InterceptHandler interface {

--- a/notifications/server.go
+++ b/notifications/server.go
@@ -67,7 +67,8 @@ func (s *server) SubscribeNotifications(
 		return nil, err
 	}
 
-	err = s.store.Register(ctx, hex.EncodeToString(pubkey.SerializeCompressed()), request.Url)
+	pubkeyStr := hex.EncodeToString(pubkey.SerializeCompressed())
+	err = s.store.Register(ctx, pubkeyStr, request.Url)
 	if err != nil {
 		log.Printf(
 			"failed to register %x for notifications on url %s: %v",
@@ -79,7 +80,7 @@ func (s *server) SubscribeNotifications(
 		return nil, ErrInternal
 	}
 
-	log.Printf("%v was successfully registered for notifications on url %s", pubkey, request.Url)
+	log.Printf("%s was successfully registered for notifications on url %s", pubkeyStr, request.Url)
 	return &SubscribeNotificationsReply{}, nil
 }
 


### PR DESCRIPTION
In some logs there were number arrays logged instead of hex strings for things like pubkeys or payment hashes. This addresses two of those occasions.