### PR TITLE
migrate: don't error when there are no migrations

### DIFF
--- a/postgresql/migrate.go
+++ b/postgresql/migrate.go
@@ -29,7 +29,9 @@ func Migrate(databaseUrl string) error {
 	}
 	log.Printf("Current database version is %d, dirty = %t", version, dirty)
 	err = m.Up()
-	if err != nil {
+	if err == migrate.ErrNoChange {
+		log.Printf("No migrations to apply.")
+	} else if err != nil {
 		return fmt.Errorf("failed to apply database migrations: %w", err)
 	}
 


### PR DESCRIPTION
The migrate `Up` method returns `ErrNoChange` ("no change") when there are no migrations to apply. This is a happy flow scenario for the migrations. Just log that there are no migrations and continue.