### PR TITLE
use common interceptor

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -8,7 +8,7 @@ env:
   LSP_REF: 'breez-node-v0.17.2-beta'
   CLIENT_REF: 'v0.16.4-breez-3'
   GO_VERSION: '^1.19'
-  CLN_VERSION: 'v24.02.1'
+  CLN_VERSION: 'v24.02.2'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/cmd/lspd/run.go
+++ b/cmd/lspd/run.go
@@ -134,7 +134,8 @@ func runLspd(cliCtx *cli.Context) error {
 			forwardSync := lnd.NewForwardSync(node.NodeId, client, historyStore)
 			go forwardSync.ForwardsSynchronize(ctx)
 			interceptor := interceptor.NewInterceptHandler(client, node.NodeConfig, interceptStore, historyStore, openingService, feeEstimator, feeStrategy, notificationService)
-			htlcInterceptor, err = lnd.NewLndHtlcInterceptor(node.NodeConfig, client, interceptor)
+			combinedHandler := common.NewCombinedHandler(interceptor)
+			htlcInterceptor, err = lnd.NewLndHtlcInterceptor(node.NodeConfig, client, combinedHandler)
 			if err != nil {
 				log.Fatalf("failed to initialize LND interceptor: %v", err)
 			}

--- a/lnd/interceptor.go
+++ b/lnd/interceptor.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/breez/lspd/common"
 	"github.com/breez/lspd/config"
-	"github.com/breez/lspd/interceptor"
 	"github.com/breez/lspd/lightning"
 	"github.com/btcsuite/btcd/btcec/v2"
 	sphinx "github.com/lightningnetwork/lightning-onion"
@@ -23,7 +22,7 @@ import (
 )
 
 type LndHtlcInterceptor struct {
-	interceptor   *interceptor.Interceptor
+	interceptor   common.InterceptHandler
 	config        *config.NodeConfig
 	client        *LndClient
 	stopRequested bool
@@ -36,7 +35,7 @@ type LndHtlcInterceptor struct {
 func NewLndHtlcInterceptor(
 	conf *config.NodeConfig,
 	client *LndClient,
-	interceptor *interceptor.Interceptor,
+	interceptor common.InterceptHandler,
 ) (*LndHtlcInterceptor, error) {
 	i := &LndHtlcInterceptor{
 		config:      conf,


### PR DESCRIPTION
Also use the common interceptor for LND nodes, to make sure logging is equivalent.