### PR TITLE
Enforce configured routing policy on channel open 

### DIFF
--- a/cln/cln_client.go
+++ b/cln/cln_client.go
@@ -194,6 +194,20 @@ func (c *ClnClient) OpenChannel(req *lightning.OpenChannelRequest) (*wire.OutPoi
 		return nil, err
 	}
 
+	if req.RoutingPolicy != nil {
+		var delay uint32 = 0
+
+		_, err = c.client.SetChannel(context.Background(), &rpc.SetchannelRequest{
+			Id:           hex.EncodeToString(fundResult.ChannelId),
+			Feebase:      &rpc.Amount{Msat: req.RoutingPolicy.BaseMsat},
+			Feeppm:       &req.RoutingPolicy.Ppm,
+			Enforcedelay: &delay,
+		})
+		if err != nil {
+			log.Printf("CLN: client.SetChannel error: %v. Ignoring error and continue funding flow.", err)
+		}
+	}
+
 	return channelPoint, nil
 }
 

--- a/interceptor/intercept_handler.go
+++ b/interceptor/intercept_handler.go
@@ -410,6 +410,10 @@ func (i *Interceptor) openChannel(paymentHash, destination []byte, incomingAmoun
 		MinConfs:       i.config.MinConfs,
 		FeeSatPerVByte: fee.SatPerVByte,
 		TargetConf:     fee.TargetConf,
+		RoutingPolicy: &lightning.RoutingPolicy{
+			Ppm:      uint32(i.config.FeeRate * 1_000_000),
+			BaseMsat: i.config.BaseFeeMsat,
+		},
 	})
 	if err != nil {
 		log.Printf("paymenthash %x, client.OpenChannelSync(%x, %v) error: %v", paymentHash, destination, capacity, err)

--- a/lightning/client.go
+++ b/lightning/client.go
@@ -17,12 +17,18 @@ type GetChannelResult struct {
 	HtlcMinimumMsat uint64
 }
 
+type RoutingPolicy struct {
+	Ppm      uint32
+	BaseMsat uint64
+}
+
 type OpenChannelRequest struct {
 	Destination    []byte
 	CapacitySat    uint64
 	MinConfs       *uint32
 	FeeSatPerVByte *float64
 	TargetConf     *uint32
+	RoutingPolicy  *RoutingPolicy
 }
 
 type Channel struct {

--- a/lnd/client.go
+++ b/lnd/client.go
@@ -244,6 +244,14 @@ func (c *LndClient) IsConnected(destination []byte) (bool, error) {
 }
 
 func (c *LndClient) OpenChannel(req *lightning.OpenChannelRequest) (*wire.OutPoint, error) {
+	var baseFee uint64
+	var feeRate uint64
+	useFees := false
+	if req.RoutingPolicy != nil {
+		useFees = true
+		baseFee = req.RoutingPolicy.BaseMsat
+		feeRate = uint64(req.RoutingPolicy.Ppm)
+	}
 	lnReq := &lnrpc.OpenChannelRequest{
 		NodePubkey:         req.Destination,
 		LocalFundingAmount: int64(req.CapacitySat),
@@ -251,6 +259,10 @@ func (c *LndClient) OpenChannel(req *lightning.OpenChannelRequest) (*wire.OutPoi
 		Private:            true,
 		CommitmentType:     lnrpc.CommitmentType_ANCHORS,
 		ZeroConf:           true,
+		BaseFee:            baseFee,
+		UseBaseFee:         useFees,
+		FeeRate:            feeRate,
+		UseFeeRate:         useFees,
 	}
 
 	if req.MinConfs != nil {


### PR DESCRIPTION
The `NODES` configuration already contains the `FeeRate` and `BaseFeeMsat` fields. In this PR these values are used to enforce that routing policy to the user's node on channel open.