### PR TITLE
fix panic for invalid cast

### DIFF
--- a/interceptor/intercept_handler.go
+++ b/interceptor/intercept_handler.go
@@ -116,7 +116,7 @@ func (i *Interceptor) Intercept(req common.InterceptRequest) common.InterceptRes
 		isConnected, err := i.client.IsConnected(nextHop)
 		if err != nil {
 			log.Printf("IsConnected(%x) error: %v", nextHop, err)
-			return &common.InterceptResult{
+			return common.InterceptResult{
 				Action:      common.INTERCEPT_FAIL_HTLC_WITH_CODE,
 				FailureCode: common.FAILURE_TEMPORARY_CHANNEL_FAILURE,
 			}, nil


### PR DESCRIPTION
Fixes panic:

```
panic: interface conversion: interface {} is *common.InterceptResult, not common.InterceptResult
goroutine 836445 [running]:
github.com/breez/lspd/interceptor.(*Interceptor).Intercept(0xc000750ea0, {{0xc0018375c0, 0x40}, 0x10000000000, {0xc0023bd3a0, 0x20, 0x20}, 0x756873f, 0x7567e88, 0xd4a2e, ...})
        github.com/breez/lspd/interceptor/intercept_handler.go:311 +0x3ce
github.com/breez/lspd/common.(*CombinedHandler).Intercept(0xc001e43a40?, {{0xc0018375c0, 0x40}, 0x10000000000, {0xc0023bd3a0, 0x20, 0x20}, 0x756873f, 0x7567e88, 0xd4a2e, ...})
        github.com/breez/lspd/common/combined_handler.go:17 +0xd4
github.com/breez/lspd/cln.(*ClnHtlcInterceptor).intercept.func2()
        github.com/breez/lspd/cln/cln_interceptor.go:156 +0x2b9
created by github.com/breez/lspd/cln.(*ClnHtlcInterceptor).intercept in goroutine 133
        github.com/breez/lspd/cln/cln_interceptor.go:135 +0x3cb
```