### PR TITLE
cln: bump max receive message size

### DIFF
--- a/cln/cln_client.go
+++ b/cln/cln_client.go
@@ -72,6 +72,7 @@ func NewClnClient(config *config.ClnConfig) (*ClnClient, error) {
 	conn, err := grpc.Dial(
 		config.GrpcAddress,
 		grpc.WithTransportCredentials(tlsCredentials),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(1024*1024*50)),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to CLN gRPC: %w", err)


### PR DESCRIPTION
The listpeerchannels response from cln can exceed the max receive message size.
`ListChannels error: rpc error: code = ResourceExhausted desc = grpc: received message larger than max (4303343 vs. 4194304)`

Bump the maximum size by default to 5MB